### PR TITLE
exclude sw and backend for now from code coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "yup": "0.28.3"
   },
   "devDependencies": {
-    "@cypress/code-coverage": "3.1.0",
+    "@cypress/code-coverage": "3.2.1",
     "@cypress/instrument-cra": "1.1.0",
     "cypress": "4.4.0",
     "eslint-config-prettier": "6.10.1",
@@ -163,5 +163,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "nyc": {
+    "exclude": ["src/serviceWorker.ts", "src/backend"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,10 +1538,10 @@
     through2 "^2.0.0"
     watchify "3.11.1"
 
-"@cypress/code-coverage@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.1.0.tgz#3a3ae0b7036b48d45c3fe5b2366ea8fc19442ded"
-  integrity sha512-LeAEA8iyAubn6BhFP24QH6ogOPKBqkuzn0+wZRlY+MG7tFUKqVmt8pWbBGzVn7hIF7YnjBFleQ24VnIiA3CscQ==
+"@cypress/code-coverage@3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.2.1.tgz#7ee5d1099dfb28c71180e18ee7cf01e24f37caed"
+  integrity sha512-Aw/krT3A2mYOX9IvhazTSOfn1C7iCPxvHnMINAbXWY5towId/ASO5seiBZjM4MoQj7FHjKriHJNf9e9WSsfrJA==
   dependencies:
     "@cypress/browserify-preprocessor" "2.2.1"
     debug "4.1.1"


### PR DESCRIPTION
we can get the backend coverage separately 

<img width="1440" alt="Screen Shot 2020-04-15 at 11 16 49 AM" src="https://user-images.githubusercontent.com/2212006/79354757-d2b99680-7f0a-11ea-823a-4a4d94208ad9.png">
