### PR TITLE
Coverage report problem 310

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,7 +7,7 @@
   "env": {
     "apiUrl": "http://localhost:3001",
     "mobileViewportWidthBreakpoint": 414,
-    "coverage": false,
+    "coverage": true,
     "codeCoverage": {
       "url": "http://localhost:3001/__coverage__"
     }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-cypress": "2.10.3",
     "eslint-plugin-prettier": "3.1.3",
-    "istanbul-lib-coverage": "^3.0.0",
     "nyc": "15.0.1",
     "prettier": "2.0.5",
     "start-server-and-test": "1.11.0"
@@ -118,7 +117,7 @@
     "test:api": "yarn cypress:run --spec 'integration/api/*'",
     "test:unit": "react-scripts test --runInBand",
     "test:unit:ci": "react-scripts test --watch false --runInBand",
-    "tsnode": "ts-node -O '{\"isolatedModules\": false, \"module\": \"commonjs\" }'",
+    "tsnode": "nyc --silent ts-node -O '{\"isolatedModules\": false, \"module\": \"commonjs\" }'",
     "tsnode:only": "ts-node -O '{\"isolatedModules\": false, \"module\": \"commonjs\" }'",
     "tsnode:test": "NODE_ENV=test ts-node -O '{\"isolatedModules\": false, \"module\": \"commonjs\" }'",
     "postdb:seed": "yarn db:seed:dev",
@@ -174,6 +173,9 @@
   "nyc": {
     "exclude": [
       "src/models/*.ts"
+    ],
+    "reporter": [
+      "html"
     ]
   }
 }


### PR DESCRIPTION
- closes #310 
- the failure was in the lcov report which we don't use anyway
- only enabled HTML coverage report, saved in `coverage` folder
- removed unnecessary Istanbul dependency, since it is included in other tools that need it

I have left nyc coverage command