### PR TITLE
Initialize history prior to react app initialization; upgrade to Xstate 4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ts-node": "8.10.1",
     "typescript": "3.9.3",
     "uuid": "8.1.0",
-    "xstate": "4.9.1",
+    "xstate": "4.10.0",
     "yup": "0.29.0"
   },
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Router } from "react-router-dom";
-import { createBrowserHistory } from "history";
+import { history } from "./utils/historyUtils";
 
 import App from "./containers/App";
 import { createMuiTheme, ThemeProvider } from "@material-ui/core";
-
-export const history = createBrowserHistory();
 
 const theme = createMuiTheme({
   palette: {

--- a/src/machines/authMachine.ts
+++ b/src/machines/authMachine.ts
@@ -1,7 +1,7 @@
 import { Machine, assign, interpret, State } from "xstate";
 import { omit } from "lodash/fp";
 import { httpClient } from "../utils/asyncUtils";
-import { history } from "../index";
+import { history } from "../utils/historyUtils";
 import { User } from "../models";
 
 export interface AuthMachineSchema {

--- a/src/utils/historyUtils.ts
+++ b/src/utils/historyUtils.ts
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from "history";
+
+export const history = createBrowserHistory();

--- a/yarn.lock
+++ b/yarn.lock
@@ -14472,10 +14472,10 @@ xregexp@^4.3.0:
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
 
-xstate@4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.9.1.tgz#da883ae0993b129ba0b54592c59b069963b0fe0a"
-  integrity sha512-cfNnRaBebnr1tvs0nHBUTyomfJx36+8MWwXceyNTZfjyELMM8nIoiBDcUzfKmpNlnAvs2ZPREos19cw6Zl4nng==
+xstate@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.10.0.tgz#f87e4ef593fe40300b8eec50a5d9f0763aa4f622"
+  integrity sha512-nncQ9gW+xgk5iUEvpBOXhbzSCS0uwzzT4bOAXxo6oUoALgbxzqEyMmaMYwuvOHrabDTdMJYnF+xe2XD8RRgWmA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Closes #370 #369 

Xstate 4.10.0 exposed an issue with the initialization of history, which is used in an authMachine action method.  Declaring the history instance in a separate module resolves the issue.