### PR TITLE
fix: add packageRules to rennovate config for resolutioned babel and express types packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,19 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "masterIssue": true
+  "masterIssue": true,
+  "packageRules": [
+    {
+      "packageNames": ["@babel/compat-data"],
+      "allowedVersions": "7.9.0"
+    },
+    {
+      "packageNames": ["@types/express"],
+      "allowedVersions": "4.17.2"
+    },
+    {
+      "packageNames": ["@types/express-serve-static-core"],
+      "allowedVersions": "4.17.2"
+    }
+  ]
 }


### PR DESCRIPTION
Update packageRules in renovate config to prevent PR's opened for new versions like #429 

These are locked to specific versions in `resolutions` in package.json and now in renovate's config