### PR TITLE
package.json: apply prettier json,md,yml on rootdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "start:api": "yarn tsnode --files backend/app.ts",
     "start:api:watch": "nodemon --exec yarn tsnode --watch 'backend' backend/app.ts",
     "start:react:proxy-server": "yarn tsnode scripts/testServer.ts",
-    "prettier": "prettier --write '**/**.{ts,js,tsx}'",
+    "prettier": "prettier --write '**/**.{ts,js,tsx}' '*.{json,md,yml}'",
     "tsnode": "nyc --silent ts-node -P tsconfig.tsnode.json",
     "tsnode:not-instrumented": "ts-node -P tsconfig.tsnode.json",
     "db:seed": "yarn tsnode scripts/generateSeedData",


### PR DESCRIPTION
Enabled prettier README.md and config files on the RootDir.

Prettier support almost popular format for example [Markdown](https://prettier.io/blog/2017/11/07/1.8.0.html).
Which could fix messy syntax to generally aligned one even without specify options.

If you don't want it then you can close immediately.

Thanks! 🤗