### PR TITLE
rename duplicate Percy snapshot

### DIFF
--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -149,24 +149,30 @@ describe("New Transaction", function () {
 
     // first let's grab the current balance from the UI
     let startBalance: string;
-    cy.get("[data-test=sidenav-user-balance]")
-      .invoke("text")
-      .then((x) => {
-        startBalance = x; // something like "$1,484.81"
-        expect(startBalance).to.match(/\$\d/);
-      });
+    if (!isMobile()) {
+      // only check the balance display in desktop resolution
+      // as it is NOT shown on mobile screen
+      cy.get("[data-test=sidenav-user-balance]")
+        .invoke("text")
+        .then((x) => {
+          startBalance = x; // something like "$1,484.81"
+          expect(startBalance).to.match(/\$\d/);
+        });
+    }
 
     cy.createTransaction(transactionPayload);
     cy.wait("@createTransaction");
     cy.getBySel("new-transaction-create-another-transaction").should("be.visible");
 
-    // make sure the new balance is displayed
-    cy.get("[data-test=sidenav-user-balance]").should(($el) => {
-      // here we only make sure the text has changed
-      // we could also convert the balance to actual number
-      // and confirm the new balance is the start balance - amount
-      expect($el.text()).to.not.equal(startBalance);
-    });
+    if (!isMobile()) {
+      // make sure the new balance is displayed
+      cy.get("[data-test=sidenav-user-balance]").should(($el) => {
+        // here we only make sure the text has changed
+        // we could also convert the balance to actual number
+        // and confirm the new balance is the start balance - amount
+        expect($el.text()).to.not.equal(startBalance);
+      });
+    }
     cy.percySnapshot("Transaction Payment Submitted Notification");
 
     cy.switchUser(ctx.contact!.username);

--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -147,9 +147,26 @@ describe("New Transaction", function () {
       receiver: ctx.contact,
     };
 
+    // first let's grab the current balance from the UI
+    let startBalance: string;
+    cy.get("[data-test=sidenav-user-balance]")
+      .invoke("text")
+      .then((x) => {
+        startBalance = x; // something like "$1,484.81"
+        expect(startBalance).to.match(/\$\d/);
+      });
+
     cy.createTransaction(transactionPayload);
     cy.wait("@createTransaction");
     cy.getBySel("new-transaction-create-another-transaction").should("be.visible");
+
+    // make sure the new balance is displayed
+    cy.get("[data-test=sidenav-user-balance]").should(($el) => {
+      // here we only make sure the text has changed
+      // we could also convert the balance to actual number
+      // and confirm the new balance is the start balance - amount
+      expect($el.text()).to.not.equal(startBalance);
+    });
     cy.percySnapshot("Transaction Payment Submitted Notification");
 
     cy.switchUser(ctx.contact!.username);

--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -179,7 +179,7 @@ describe("New Transaction", function () {
     cy.createTransaction(transactionPayload);
     cy.wait("@createTransaction");
     cy.getBySel("new-transaction-create-another-transaction").should("be.visible");
-    cy.percySnapshot("Transaction Payment Submitted Notification");
+    cy.percySnapshot("receiver - Transaction Payment Submitted Notification");
 
     cy.switchUser(ctx.contact!.username);
 


### PR DESCRIPTION
Which is what cases https://percy.io/cypress-io/cypress-realworld-app/builds/7112759 I believe

In the future PR, I will do a separate PR to wrap `cy.percySnapshot` to have full test title and optional suffix to avoid image snapshot clashes, like I did in https://github.com/bahmutov/sudoku-qafest/blob/main/cypress/support/index.js#L9

- [x] remove duplicate screenshot name
- [x] change a test to wait for the UI to refresh the balance before taking visual snapshot
- [x] skip that balance check in mobile resolution (since the balance is not shown)