### PR TITLE
tighten the search test

### DIFF
--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -248,13 +248,16 @@ describe("New Transaction", function () {
     cy.wait("@allUsers");
 
     searchAttrs.forEach((attr: keyof User) => {
+      cy.log(`Searching by **${attr}**`);
       cy.getBySel("user-list-search-input").type(targetUser[attr] as string, { force: true });
       cy.wait("@usersSearch");
 
       cy.getBySelLike("user-list-item")
+        // make sure the list of results is fully updated
+        .should("have.length", 1)
         .first()
         .contains(targetUser[attr] as string);
-      cy.percySnapshot(`User List for Search: ${targetUser[attr]}`);
+      cy.percySnapshot(`User List for Search: ${attr} = ${targetUser[attr]}`);
 
       cy.focused().clear();
       cy.getBySel("users-list").should("be.empty");


### PR DESCRIPTION
Visual flake because the search with autocomplete can have a race condition. Described in https://cypress-io.ghost.io/blog/2020/10/02/debug-a-flaky-visual-regression-test/#bonus-the-search-results-test

Note: seems the search by full email returns 2 matches, and the second seems completely unrelated?!

<img width="858" alt="Screen Shot 2020-10-22 at 8 39 49 AM" src="https://user-images.githubusercontent.com/2212006/96877794-19eb8b80-1448-11eb-90f6-a29131bf505b.png">
