### PR TITLE
Use Circle medium+ resource class for Firefox jobs; Enable video recordings for Firefox again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ executors:
   with-chrome-and-firefox:
     docker:
       - image: "cypress/browsers:node12.14.1-chrome85-ff81"
+    resource_class: medium+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Commands ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 commands:
@@ -104,7 +105,7 @@ linux-workflow: &linux-workflow
         name: "UI Tests - Firefox"
         browser: firefox
         spec: cypress/tests/ui/*
-        config: video=false
+        #config: video=false
         executor: with-chrome-and-firefox
         wait-on: "http://localhost:3000"
         yarn: true
@@ -124,7 +125,8 @@ linux-workflow: &linux-workflow
         name: "UI Tests - Firefox - Mobile"
         browser: firefox
         spec: cypress/tests/ui/*
-        config: viewportWidth=375,viewportHeight=667,video=false
+        #config: viewportWidth=375,viewportHeight=667,video=false
+        config: viewportWidth=375,viewportHeight=667
         executor: with-chrome-and-firefox
         wait-on: "http://localhost:3000"
         yarn: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,6 @@ executors:
   with-chrome-and-firefox:
     docker:
       - image: "cypress/browsers:node12.14.1-chrome85-ff81"
-    resource_class: medium+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Commands ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 commands:
@@ -106,6 +105,7 @@ linux-workflow: &linux-workflow
         browser: firefox
         spec: cypress/tests/ui/*
         #config: video=false
+        resource_class: medium+
         executor: with-chrome-and-firefox
         wait-on: "http://localhost:3000"
         yarn: true
@@ -127,6 +127,7 @@ linux-workflow: &linux-workflow
         spec: cypress/tests/ui/*
         #config: viewportWidth=375,viewportHeight=667,video=false
         config: viewportWidth=375,viewportHeight=667
+        resource_class: medium+
         executor: with-chrome-and-firefox
         wait-on: "http://localhost:3000"
         yarn: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,10 @@ executors:
   with-chrome-and-firefox:
     docker:
       - image: "cypress/browsers:node12.14.1-chrome85-ff81"
+  with-chrome-and-firefox-medium-plus:
+    docker:
+      - image: "cypress/browsers:node12.14.1-chrome85-ff81"
+    resource_class: medium+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Commands ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 commands:
@@ -104,9 +108,7 @@ linux-workflow: &linux-workflow
         name: "UI Tests - Firefox"
         browser: firefox
         spec: cypress/tests/ui/*
-        #config: video=false
-        resource_class: medium+
-        executor: with-chrome-and-firefox
+        executor: with-chrome-and-firefox-medium-plus
         wait-on: "http://localhost:3000"
         yarn: true
         start: yarn start:ci
@@ -125,10 +127,8 @@ linux-workflow: &linux-workflow
         name: "UI Tests - Firefox - Mobile"
         browser: firefox
         spec: cypress/tests/ui/*
-        #config: viewportWidth=375,viewportHeight=667,video=false
         config: viewportWidth=375,viewportHeight=667
-        resource_class: medium+
-        executor: with-chrome-and-firefox
+        executor: with-chrome-and-firefox-medium-plus
         wait-on: "http://localhost:3000"
         yarn: true
         start: yarn start:ci


### PR DESCRIPTION
Use the medium+ resource in Circle to allow video to be enabled again in Firefox jobs.