### PR TITLE
Migrate to visualSnapshot command to dynamically generate Percy snapshot name

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -35,6 +35,11 @@ declare namespace Cypress {
      */
     window(options?: Partial<Loggable & Timeoutable>): Chainable<CustomWindow>;
 
+    /**
+     * Custom command to make taking Percy snapshots with full name formed from the test title + suffix easier
+     */
+    visualSnapshot(maybeName): Chainable<any>;
+
     getBySel(dataTestAttribute: string, args?: any): Chainable<Element>;
     getBySelLike(dataTestPrefixAttribute: string, args?: any): Chainable<Element>;
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -3,7 +3,27 @@
 
 import { pick } from "lodash/fp";
 import { format as formatDate } from "date-fns";
+import "@percy/cypress";
 import { isMobile } from "./utils";
+
+// custom command to make taking snapshots with full name
+// formed from the test title + suffix easier
+// cy.visualSnapshot() // default full test title
+// cy.visualSnapshot('clicked') // full test title + ' - clicked'
+// also sets the width and height to the current viewport
+Cypress.Commands.add("visualSnapshot", (maybeName) => {
+  // @ts-ignore
+  let snapshotTitle = cy.state("runnable").fullTitle();
+  if (maybeName) {
+    snapshotTitle = snapshotTitle + " - " + maybeName;
+  }
+  cy.percySnapshot(snapshotTitle, {
+    // @ts-ignore
+    widths: [cy.state("viewportWidth")],
+    // @ts-ignore
+    minHeight: cy.state("viewportHeight"),
+  });
+});
 
 Cypress.Commands.add("getBySel", (selector, ...args) => {
   return cy.get(`[data-test=${selector}]`, ...args);

--- a/cypress/tests/ui/auth.spec.ts
+++ b/cypress/tests/ui/auth.spec.ts
@@ -13,7 +13,7 @@ describe("User Sign-up and Login", function () {
   it("should redirect unauthenticated user to signin page", function () {
     cy.visit("/personal");
     cy.location("pathname").should("equal", "/signin");
-    cy.percySnapshot("Redirect to SignIn");
+    cy.visualSnapshot("Redirect to SignIn");
   });
 
   it("should remember a user for 30 days after login", function () {
@@ -30,7 +30,7 @@ describe("User Sign-up and Login", function () {
     }
     cy.getBySel("sidenav-signout").click();
     cy.location("pathname").should("eq", "/signin");
-    cy.percySnapshot("Redirect to SignIn");
+    cy.visualSnapshot("Redirect to SignIn");
   });
 
   it("should allow a visitor to sign-up, login, and logout", function () {
@@ -46,14 +46,14 @@ describe("User Sign-up and Login", function () {
 
     cy.getBySel("signup").click();
     cy.getBySel("signup-title").should("be.visible").and("contain", "Sign Up");
-    cy.percySnapshot("Sign Up Title");
+    cy.visualSnapshot("Sign Up Title");
 
     cy.getBySel("signup-first-name").type(userInfo.firstName);
     cy.getBySel("signup-last-name").type(userInfo.lastName);
     cy.getBySel("signup-username").type(userInfo.username);
     cy.getBySel("signup-password").type(userInfo.password);
     cy.getBySel("signup-confirmPassword").type(userInfo.password);
-    cy.percySnapshot("About to Sign Up");
+    cy.visualSnapshot("About to Sign Up");
     cy.getBySel("signup-submit").click();
     cy.wait("@signup");
 
@@ -62,7 +62,7 @@ describe("User Sign-up and Login", function () {
 
     // Onboarding
     cy.getBySel("user-onboarding-dialog").should("be.visible");
-    cy.percySnapshot("User Onboarding Dialog");
+    cy.visualSnapshot("User Onboarding Dialog");
     cy.getBySel("user-onboarding-next").click();
 
     cy.getBySel("user-onboarding-dialog-title").should("contain", "Create Bank Account");
@@ -70,18 +70,18 @@ describe("User Sign-up and Login", function () {
     cy.getBySelLike("bankName-input").type("The Best Bank");
     cy.getBySelLike("accountNumber-input").type("123456789");
     cy.getBySelLike("routingNumber-input").type("987654321");
-    cy.percySnapshot("About to complete User Onboarding");
+    cy.visualSnapshot("About to complete User Onboarding");
     cy.getBySelLike("submit").click();
 
     cy.wait("@createBankAccount");
 
     cy.getBySel("user-onboarding-dialog-title").should("contain", "Finished");
     cy.getBySel("user-onboarding-dialog-content").should("contain", "You're all set!");
-    cy.percySnapshot("Finished User Onboarding");
+    cy.visualSnapshot("Finished User Onboarding");
     cy.getBySel("user-onboarding-next").click();
 
     cy.getBySel("transaction-list").should("be.visible");
-    cy.percySnapshot("Transaction List is visible after User Onboarding");
+    cy.visualSnapshot("Transaction List is visible after User Onboarding");
 
     // Logout User
     if (isMobile()) {
@@ -89,7 +89,7 @@ describe("User Sign-up and Login", function () {
     }
     cy.getBySel("sidenav-signout").click();
     cy.location("pathname").should("eq", "/signin");
-    cy.percySnapshot("Redirect to SignIn");
+    cy.visualSnapshot("Redirect to SignIn");
   });
 
   it("should display login errors", function () {
@@ -97,16 +97,16 @@ describe("User Sign-up and Login", function () {
 
     cy.getBySel("signin-username").type("User").find("input").clear().blur();
     cy.get("#username-helper-text").should("be.visible").and("contain", "Username is required");
-    cy.percySnapshot("Display Username is Required Error");
+    cy.visualSnapshot("Display Username is Required Error");
 
     cy.getBySel("signin-password").type("abc").find("input").blur();
     cy.get("#password-helper-text")
       .should("be.visible")
       .and("contain", "Password must contain at least 4 characters");
-    cy.percySnapshot("Display Password Error");
+    cy.visualSnapshot("Display Password Error");
 
     cy.getBySel("signin-submit").should("be.disabled");
-    cy.percySnapshot("Sign In Submit Disabled");
+    cy.visualSnapshot("Sign In Submit Disabled");
   });
 
   it("should display signup errors", function () {
@@ -128,10 +128,10 @@ describe("User Sign-up and Login", function () {
     cy.get("#confirmPassword-helper-text")
       .should("be.visible")
       .and("contain", "Password does not match");
-    cy.percySnapshot("Display Sign Up Required Errors");
+    cy.visualSnapshot("Display Sign Up Required Errors");
 
     cy.getBySel("signup-submit").should("be.disabled");
-    cy.percySnapshot("Sign Up Submit Disabled");
+    cy.visualSnapshot("Sign Up Submit Disabled");
   });
 
   it("should error for an invalid user", function () {
@@ -140,7 +140,7 @@ describe("User Sign-up and Login", function () {
     cy.getBySel("signin-error")
       .should("be.visible")
       .and("have.text", "Username or password is invalid");
-    cy.percySnapshot("Sign In, Invalid Username and Password, Username or Password is Invalid");
+    cy.visualSnapshot("Sign In, Invalid Username and Password, Username or Password is Invalid");
   });
 
   it("should error for an invalid password for existing user", function () {
@@ -151,6 +151,6 @@ describe("User Sign-up and Login", function () {
     cy.getBySel("signin-error")
       .should("be.visible")
       .and("have.text", "Username or password is invalid");
-    cy.percySnapshot("Sign In, Invalid Username, Username or Password is Invalid");
+    cy.visualSnapshot("Sign In, Invalid Username, Username or Password is Invalid");
   });
 });

--- a/cypress/tests/ui/bankaccounts.spec.ts
+++ b/cypress/tests/ui/bankaccounts.spec.ts
@@ -33,12 +33,12 @@ describe("Bank Accounts", function () {
 
     cy.getBySel("bankaccount-new").click();
     cy.location("pathname").should("eq", "/bankaccounts/new");
-    cy.percySnapshot("Display New Bank Account Form");
+    cy.visualSnapshot("Display New Bank Account Form");
 
     cy.getBySelLike("bankName-input").type("The Best Bank");
     cy.getBySelLike("routingNumber-input").type("987654321");
     cy.getBySelLike("accountNumber-input").type("123456789");
-    cy.percySnapshot("Fill out New Bank Account Form");
+    cy.visualSnapshot("Fill out New Bank Account Form");
     cy.getBySelLike("submit").click();
 
     cy.wait("@createBankAccount");
@@ -47,7 +47,7 @@ describe("Bank Accounts", function () {
       .should("have.length", 2)
       .eq(1)
       .should("contain", "The Best Bank");
-    cy.percySnapshot("Bank Account Created");
+    cy.visualSnapshot("Bank Account Created");
   });
 
   it("should display bank account form errors", function () {
@@ -99,7 +99,6 @@ describe("Bank Accounts", function () {
     cy.get("#bankaccount-accountNumber-input-helper-text").should("not.exist");
     cy.getBySelLike("accountNumber-input").find("input").clear();
 
-
     // Max 12 gdigit
     cy.getBySelLike("accountNumber-input").type("123456789111").find("input").blur();
     cy.get("#bankaccount-accountNumber-input-helper-text").should("not.exist");
@@ -111,7 +110,7 @@ describe("Bank Accounts", function () {
       .and("contain", "Must contain no more than 12 digits");
 
     cy.getBySel("bankaccount-submit").should("be.disabled");
-    cy.percySnapshot("Bank Account Form with Errors and Submit button disabled");
+    cy.visualSnapshot("Bank Account Form with Errors and Submit button disabled");
   });
 
   it("soft deletes a bank account", function () {
@@ -120,7 +119,7 @@ describe("Bank Accounts", function () {
 
     cy.wait("@deleteBankAccount");
     cy.getBySelLike("list-item").children().contains("Deleted");
-    cy.percySnapshot("Soft Delete Bank Account");
+    cy.visualSnapshot("Soft Delete Bank Account");
   });
 
   // TODO: [enhancement] the onboarding modal assertion can be removed after adding "onboarded" flag to user profile
@@ -133,6 +132,6 @@ describe("Bank Accounts", function () {
     cy.getBySel("bankaccount-list").should("not.exist");
     cy.getBySel("empty-list-header").should("contain", "No Bank Accounts");
     cy.getBySel("user-onboarding-dialog").should("be.visible");
-    cy.percySnapshot("User Onboarding Dialog is Visible");
+    cy.visualSnapshot("User Onboarding Dialog is Visible");
   });
 });

--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -44,14 +44,14 @@ describe("New Transaction", function () {
 
     cy.getBySel("user-list-search-input").type(ctx.contact!.firstName, { force: true });
     cy.wait("@usersSearch");
-    cy.percySnapshot("User Search First Name Input");
+    cy.visualSnapshot("User Search First Name Input");
 
     cy.getBySelLike("user-list-item").contains(ctx.contact!.firstName).click({ force: true });
-    cy.percySnapshot("User Search First Name List Item");
+    cy.visualSnapshot("User Search First Name List Item");
 
     cy.getBySelLike("amount-input").type(payment.amount);
     cy.getBySelLike("description-input").type(payment.description);
-    cy.percySnapshot("Amount and Description Input");
+    cy.visualSnapshot("Amount and Description Input");
     cy.getBySelLike("submit-payment").click();
     cy.wait(["@createTransaction", "@getUserProfile"]);
     cy.getBySel("alert-bar-success")
@@ -67,7 +67,7 @@ describe("New Transaction", function () {
     }
 
     cy.getBySelLike("user-balance").should("contain", updatedAccountBalance);
-    cy.percySnapshot("Updated User Balance");
+    cy.visualSnapshot("Updated User Balance");
 
     if (isMobile()) {
       cy.get(".MuiBackdrop-root").click({ force: true });
@@ -83,7 +83,7 @@ describe("New Transaction", function () {
     cy.database("find", "users", { id: ctx.contact!.id })
       .its("balance")
       .should("equal", ctx.contact!.balance + parseInt(payment.amount) * 100);
-    cy.percySnapshot("Personal List Validate Transaction in List");
+    cy.visualSnapshot("Personal List Validate Transaction in List");
   });
 
   it("navigates to the new transaction form, selects a user and submits a transaction request", function () {
@@ -96,23 +96,23 @@ describe("New Transaction", function () {
     cy.wait("@allUsers");
 
     cy.getBySelLike("user-list-item").contains(ctx.contact!.firstName).click({ force: true });
-    cy.percySnapshot("User Search First Name Input");
+    cy.visualSnapshot("User Search First Name Input");
 
     cy.getBySelLike("amount-input").type(request.amount);
     cy.getBySelLike("description-input").type(request.description);
-    cy.percySnapshot("Amount and Description Input");
+    cy.visualSnapshot("Amount and Description Input");
     cy.getBySelLike("submit-request").click();
     cy.wait("@createTransaction");
     cy.getBySel("alert-bar-success")
       .should("be.visible")
       .and("have.text", "Transaction Submitted!");
-    cy.percySnapshot("Transaction Request Submitted Notification");
+    cy.visualSnapshot("Transaction Request Submitted Notification");
 
     cy.getBySelLike("return-to-transactions").click();
     cy.getBySelLike("personal-tab").click().should("have.class", "Mui-selected");
 
     cy.getBySelLike("transaction-item").should("contain", request.description);
-    cy.percySnapshot("Transaction Item Description in List");
+    cy.visualSnapshot("Transaction Item Description in List");
   });
 
   it("displays new transaction errors", function () {
@@ -133,7 +133,7 @@ describe("New Transaction", function () {
 
     cy.getBySelLike("submit-request").should("be.disabled");
     cy.getBySelLike("submit-payment").should("be.disabled");
-    cy.percySnapshot("New Transaction Errors with Submit Payment/Request Buttons Disabled");
+    cy.visualSnapshot("New Transaction Errors with Submit Payment/Request Buttons Disabled");
   });
 
   it("submits a transaction payment and verifies the deposit for the receiver", function () {
@@ -173,7 +173,7 @@ describe("New Transaction", function () {
         expect($el.text()).to.not.equal(startBalance);
       });
     }
-    cy.percySnapshot("Transaction Payment Submitted Notification");
+    cy.visualSnapshot("Transaction Payment Submitted Notification");
 
     cy.switchUser(ctx.contact!.username);
 
@@ -186,7 +186,7 @@ describe("New Transaction", function () {
     }
 
     cy.getBySelLike("user-balance").should("contain", updatedAccountBalance);
-    cy.percySnapshot("Verify Updated Sender Account Balance");
+    cy.visualSnapshot("Verify Updated Sender Account Balance");
   });
 
   it("submits a transaction request and accepts the request for the receiver", function () {
@@ -202,7 +202,7 @@ describe("New Transaction", function () {
     cy.createTransaction(transactionPayload);
     cy.wait("@createTransaction");
     cy.getBySel("new-transaction-create-another-transaction").should("be.visible");
-    cy.percySnapshot("receiver - Transaction Payment Submitted Notification");
+    cy.visualSnapshot("receiver - Transaction Payment Submitted Notification");
 
     cy.switchUser(ctx.contact!.username);
 
@@ -214,7 +214,7 @@ describe("New Transaction", function () {
       .first()
       .should("contain", transactionPayload.description)
       .click({ force: true });
-    cy.percySnapshot("Navigate to Transaction Item");
+    cy.visualSnapshot("Navigate to Transaction Item");
 
     cy.getBySelLike("accept-request").click();
     cy.wait("@updateTransaction").its("status").should("equal", 204);
@@ -223,7 +223,7 @@ describe("New Transaction", function () {
     cy.getBySelLike("sender-avatar").should("be.visible");
     cy.getBySelLike("receiver-avatar").should("be.visible");
     cy.getBySelLike("transaction-description").should("be.visible");
-    cy.percySnapshot("Accept Transaction Request");
+    cy.visualSnapshot("Accept Transaction Request");
 
     cy.switchUser(ctx.user!.username);
 
@@ -236,7 +236,7 @@ describe("New Transaction", function () {
     }
 
     cy.getBySelLike("user-balance").should("contain", updatedAccountBalance);
-    cy.percySnapshot("Verify Updated Sender Account Balance");
+    cy.visualSnapshot("Verify Updated Sender Account Balance");
   });
 
   context("searches for a user by attribute", function () {
@@ -272,11 +272,11 @@ describe("New Transaction", function () {
               .contains(targetUser[attr] as string);
           });
 
-        cy.percySnapshot(`User List for Search: ${attr} = ${targetUser[attr]}`);
+        cy.visualSnapshot(`User List for Search: ${attr} = ${targetUser[attr]}`);
 
         cy.focused().clear();
         cy.getBySel("users-list").should("be.empty");
-        cy.percySnapshot("User List Clear Search");
+        cy.visualSnapshot("User List Clear Search");
       });
     });
   });

--- a/cypress/tests/ui/notifications.spec.ts
+++ b/cypress/tests/ui/notifications.spec.ts
@@ -43,7 +43,7 @@ describe("Notifications", function () {
         .then((notificationCount) => {
           cy.getBySel("nav-top-notifications-count").should("have.text", `${notificationCount}`);
         });
-      cy.percySnapshot("Renders the notifications badge with count");
+      cy.visualSnapshot("Renders the notifications badge with count");
 
       const likesCountSelector = "[data-test*=transaction-like-count]";
       cy.contains(likesCountSelector, 0);
@@ -52,10 +52,10 @@ describe("Notifications", function () {
       // the number of likes
       cy.getBySelLike("like-button").should("be.disabled");
       cy.contains(likesCountSelector, 1);
-      cy.percySnapshot("Like Count Incremented");
+      cy.visualSnapshot("Like Count Incremented");
 
       cy.switchUser(ctx.userB.username);
-      cy.percySnapshot(`Notifications - User Interactions - Switch to User ${ctx.userB.username}`);
+      cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.wait("@getNotifications")
         .its("response.body.results.length")
@@ -78,7 +78,7 @@ describe("Notifications", function () {
       cy.get("@preDismissedNotificationCount").then((count) => {
         cy.getBySelLike("notification-list-item").should("have.length.lessThan", Number(count));
       });
-      cy.percySnapshot("Notification count after notification dismissed");
+      cy.visualSnapshot("Notification count after notification dismissed");
     });
 
     it("User C likes a transaction between User A and User B; User B and get notifications that User C liked transaction", function () {
@@ -96,10 +96,10 @@ describe("Notifications", function () {
       cy.getBySelLike("like-button").click();
       cy.getBySelLike("like-button").should("be.disabled");
       cy.contains(likesCountSelector, 1);
-      cy.percySnapshot("Like Count Incremented");
+      cy.visualSnapshot("Like Count Incremented");
 
       cy.switchUser(ctx.userA.username);
-      cy.percySnapshot(`Notifications - Like Transaction - Switch to User ${ctx.userA.username}`);
+      cy.visualSnapshot(`Switch to User ${ctx.userA.username}`);
 
       cy.getBySelLike("notifications-link").click();
 
@@ -112,10 +112,10 @@ describe("Notifications", function () {
         .first()
         .should("contain", ctx.userC.firstName)
         .and("contain", "liked");
-      cy.percySnapshot("User A Notified of User B Like");
+      cy.visualSnapshot("User A Notified of User B Like");
 
       cy.switchUser(ctx.userB.username);
-      cy.percySnapshot(`Notifications - Like Transaction - Switch to User ${ctx.userB.username}`);
+      cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
 
@@ -126,12 +126,12 @@ describe("Notifications", function () {
         .first()
         .should("contain", ctx.userC.firstName)
         .and("contain", "liked");
-      cy.percySnapshot("User B Notified of User C Like");
+      cy.visualSnapshot("User B Notified of User C Like");
     });
 
     it("User A comments on a transaction of User B; User B gets notification that User A commented on their transaction", function () {
       cy.loginByXstate(ctx.userA.username);
-      cy.percySnapshot();
+      cy.visualSnapshot();
 
       cy.database("find", "transactions", { senderId: ctx.userB.id }).then(
         (transaction: Transaction) => {
@@ -144,9 +144,7 @@ describe("Notifications", function () {
       cy.wait("@postComment");
 
       cy.switchUser(ctx.userB.username);
-      cy.percySnapshot(
-        `Notifications - Comment Transaction - Switch to User ${ctx.userB.username}`
-      );
+      cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
 
@@ -157,7 +155,7 @@ describe("Notifications", function () {
         .first()
         .should("contain", ctx.userA?.firstName)
         .and("contain", "commented");
-      cy.percySnapshot("User A Notified of User B Comment");
+      cy.visualSnapshot("User A Notified of User B Comment");
     });
 
     it("User C comments on a transaction between User A and User B; User A and B get notifications that User C commented on their transaction", function () {
@@ -175,10 +173,8 @@ describe("Notifications", function () {
       cy.wait("@postComment");
 
       cy.switchUser(ctx.userA.username);
-      cy.percySnapshot("Switch to User A");
-      cy.percySnapshot(
-        `Notifications - Comment Transaction Two Users - Switch to User ${ctx.userA.username}`
-      );
+      cy.visualSnapshot("Switch to User A");
+      cy.visualSnapshot(`Switch to User ${ctx.userA.username}`);
 
       cy.getBySelLike("notifications-link").click();
 
@@ -189,12 +185,10 @@ describe("Notifications", function () {
         .first()
         .should("contain", ctx.userC.firstName)
         .and("contain", "commented");
-      cy.percySnapshot("User A Notified of User C Comment");
+      cy.visualSnapshot("User A Notified of User C Comment");
 
       cy.switchUser(ctx.userB.username);
-      cy.percySnapshot(
-        `Notifications - Comment Transaction Two Users - Switch to User ${ctx.userB.username}`
-      );
+      cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
       cy.getBySelLike("notification-list-item")
@@ -202,7 +196,7 @@ describe("Notifications", function () {
         .first()
         .should("contain", ctx.userC.firstName)
         .and("contain", "commented");
-      cy.percySnapshot("User B Notified of User C Comment");
+      cy.visualSnapshot("User B Notified of User C Comment");
     });
 
     it("User A sends a payment to User B", function () {
@@ -219,15 +213,16 @@ describe("Notifications", function () {
       cy.wait("@createTransaction");
 
       cy.switchUser(ctx.userB.username);
-      cy.percySnapshot(`Notifications - Payment - Switch to User ${ctx.userB.username}`);
+      cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
-      cy.percySnapshot();
+      cy.visualSnapshot("Navigate to Notifications");
+
       cy.getBySelLike("notification-list-item")
         .first()
         .should("contain", ctx.userB.firstName)
         .and("contain", "received payment");
-      cy.percySnapshot("User B Notified of Payment");
+      cy.visualSnapshot("User B Notified of Payment");
     });
 
     it("User A sends a payment request to User C", function () {
@@ -244,13 +239,13 @@ describe("Notifications", function () {
       cy.wait("@createTransaction");
 
       cy.switchUser(ctx.userC.username);
-      cy.percySnapshot(`Notifications - Payment Request - Switch to User ${ctx.userC.username}`);
+      cy.visualSnapshot(`Switch to User ${ctx.userC.username}`);
 
       cy.getBySelLike("notifications-link").click();
       cy.getBySelLike("notification-list-item")
         .should("contain", ctx.userA.firstName)
         .and("contain", "requested payment");
-      cy.percySnapshot("User C Notified of Request from User A");
+      cy.visualSnapshot("User C Notified of Request from User A");
     });
   });
 
@@ -266,6 +261,6 @@ describe("Notifications", function () {
     cy.location("pathname").should("equal", "/notifications");
     cy.getBySel("notification-list").should("not.exist");
     cy.getBySel("empty-list-header").should("contain", "No Notifications");
-    cy.percySnapshot("No Notifications");
+    cy.visualSnapshot("No Notifications");
   });
 });

--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -64,23 +64,23 @@ describe("Transaction Feed", function () {
       cy.wait("@notifications");
       if (isMobile()) {
         cy.getBySel("sidenav-home").should("not.exist");
-        cy.percySnapshot("Mobile Initial Side Navigation Not Visible");
+        cy.visualSnapshot("Mobile Initial Side Navigation Not Visible");
         cy.getBySel("sidenav-toggle").click();
         cy.getBySel("sidenav-home").should("be.visible");
-        cy.percySnapshot("Mobile Toggle Side Navigation Visible");
+        cy.visualSnapshot("Mobile Toggle Side Navigation Visible");
         cy.get(".MuiBackdrop-root").click({ force: true });
         cy.getBySel("sidenav-home").should("not.exist");
-        cy.percySnapshot("Mobile Home Link Side Navigation Not Visible");
+        cy.visualSnapshot("Mobile Home Link Side Navigation Not Visible");
 
         cy.getBySel("sidenav-toggle").click();
         cy.getBySel("sidenav-home").click().should("not.exist");
-        cy.percySnapshot("Mobile Toggle Side Navigation Not Visible");
+        cy.visualSnapshot("Mobile Toggle Side Navigation Not Visible");
       } else {
         cy.getBySel("sidenav-home").should("be.visible");
-        cy.percySnapshot("Desktop Side Navigation Visible");
+        cy.visualSnapshot("Desktop Side Navigation Visible");
         cy.getBySel("sidenav-toggle").click();
         cy.getBySel("sidenav-home").should("not.be.visible");
-        cy.percySnapshot("Desktop Side Navigation Not Visible");
+        cy.visualSnapshot("Desktop Side Navigation Not Visible");
       }
     });
   });
@@ -162,7 +162,7 @@ describe("Transaction Feed", function () {
               .should("contain", `+${formattedAmount}`)
               .should("have.css", "color", "rgb(76, 175, 80)");
           });
-          cy.percySnapshot("Transaction Item");
+          cy.visualSnapshot("Transaction Item");
         });
     });
 
@@ -174,7 +174,7 @@ describe("Transaction Feed", function () {
           .contains(feed.tabLabel, { matchCase: false })
           .should("have.css", { "text-transform": "uppercase" });
         cy.getBySel("list-skeleton").should("not.exist");
-        cy.percySnapshot(`Paginate ${feedName}`);
+        cy.visualSnapshot(`Paginate ${feedName}`);
 
         cy.wait(`@${feed.routeAlias}`)
           .its("response.body.results")
@@ -193,7 +193,7 @@ describe("Transaction Feed", function () {
           .then(({ results, pageData }) => {
             expect(results).have.length(Cypress.env("paginationPageSize"));
             expect(pageData.page).to.equal(2);
-            cy.percySnapshot(`Paginate ${feedName} Next Page`);
+            cy.visualSnapshot(`Paginate ${feedName} Next Page`);
             cy.nextTransactionFeedPage(feed.service, pageData.totalPages);
           });
 
@@ -203,7 +203,7 @@ describe("Transaction Feed", function () {
             expect(results).to.have.length.least(1);
             expect(pageData.page).to.equal(pageData.totalPages);
             expect(pageData.hasNextPages).to.equal(false);
-            cy.percySnapshot(`Paginate ${feedName} Last Page`);
+            cy.visualSnapshot(`Paginate ${feedName} Last Page`);
           });
       });
     });
@@ -214,10 +214,10 @@ describe("Transaction Feed", function () {
       it("closes date range picker modal", () => {
         cy.getBySelLike("filter-date-range-button").click({ force: true });
         cy.get(".Cal__Header__root").should("be.visible");
-        cy.percySnapshot("Mobile Open Date Range Picker");
+        cy.visualSnapshot("Mobile Open Date Range Picker");
         cy.getBySel("date-range-filter-drawer-close").click();
         cy.get(".Cal__Header__root").should("not.exist");
-        cy.percySnapshot("Mobile Close Date Range Picker");
+        cy.visualSnapshot("Mobile Close Date Range Picker");
       });
     }
 
@@ -238,7 +238,7 @@ describe("Transaction Feed", function () {
             .then((transactions: Transaction[]) => {
               cy.getBySelLike("transaction-item").should("have.length", transactions.length);
 
-              cy.percySnapshot("Date Range Filtered Transactions");
+              cy.visualSnapshot("Date Range Filtered Transactions");
               transactions.forEach(({ createdAt }) => {
                 const createdAtDate = startOfDayUTC(new Date(createdAt));
 
@@ -264,7 +264,7 @@ describe("Transaction Feed", function () {
               .its("response.body.results")
               .should("deep.equal", unfilteredResults);
           });
-          cy.percySnapshot("Unfiltered Transactions");
+          cy.visualSnapshot("Unfiltered Transactions");
         });
       });
 
@@ -284,7 +284,7 @@ describe("Transaction Feed", function () {
           .should("have.attr", "href", "/transaction/new")
           .contains("create a transaction", { matchCase: false })
           .should("have.css", { "text-transform": "uppercase" });
-        cy.percySnapshot("No Transactions");
+        cy.visualSnapshot("No Transactions");
       });
     });
   });
@@ -319,7 +319,7 @@ describe("Transaction Feed", function () {
           expect(urlParams.get("amountMin")).to.equal(`${rawAmountMin}`);
           expect(urlParams.get("amountMax")).to.equal(`${rawAmountMax}`);
 
-          cy.percySnapshot("Amount Range Filtered Transactions");
+          cy.visualSnapshot("Amount Range Filtered Transactions");
           transactions.forEach(({ amount }) => {
             expect(amount).to.be.within(rawAmountMin, rawAmountMax);
           });
@@ -330,7 +330,7 @@ describe("Transaction Feed", function () {
           cy.wait(`@${feed.routeAlias}`)
             .its("response.body.results")
             .should("deep.equal", unfilteredResults);
-          cy.percySnapshot("Unfiltered Transactions");
+          cy.visualSnapshot("Unfiltered Transactions");
         });
 
         if (isMobile()) {
@@ -358,7 +358,7 @@ describe("Transaction Feed", function () {
           .should("have.attr", "href", "/transaction/new")
           .contains("create a transaction", { matchCase: false })
           .should("have.css", { "text-transform": "uppercase" });
-        cy.percySnapshot("No Transactions");
+        cy.visualSnapshot("No Transactions");
       });
     });
   });
@@ -377,7 +377,7 @@ describe("Transaction Feed", function () {
           const transactionParticipants = [transaction.senderId, transaction.receiverId];
           expect(transactionParticipants).to.include(ctx.user!.id);
         });
-      cy.percySnapshot("Personal Transactions");
+      cy.visualSnapshot("Personal Transactions");
     });
 
     it("first five items belong to contacts in public feed", function () {
@@ -395,7 +395,7 @@ describe("Transaction Feed", function () {
           const message = `"${contactsInTransaction}" are contacts of ${ctx.user!.id}`;
           expect(contactsInTransaction, message).to.not.be.empty;
         });
-      cy.percySnapshot("First 5 Transaction Items belong to contacts");
+      cy.visualSnapshot("First 5 Transaction Items belong to contacts");
     });
 
     it("friends feed only shows contact transactions", function () {
@@ -415,7 +415,7 @@ describe("Transaction Feed", function () {
           const message = `"${contactsInTransaction}" are contacts of ${ctx.user!.id}`;
           expect(contactsInTransaction, message).to.not.be.empty;
         });
-      cy.percySnapshot("Friends Feed only shows contacts transactions");
+      cy.visualSnapshot("Friends Feed only shows contacts transactions");
     });
   });
 });

--- a/cypress/tests/ui/transaction-view.spec.ts
+++ b/cypress/tests/ui/transaction-view.spec.ts
@@ -44,7 +44,7 @@ describe("Transaction View", function () {
     cy.getBySelLike("transaction-item").first().click();
     cy.location("pathname").should("include", "/transaction");
     cy.getBySel("nav-transaction-tabs").should("not.exist");
-    cy.percySnapshot("Transaction Navigation Tabs Hidden");
+    cy.visualSnapshot("Transaction Navigation Tabs Hidden");
   });
 
   it("likes a transaction", function () {
@@ -54,7 +54,7 @@ describe("Transaction View", function () {
     cy.getBySelLike("like-button").click();
     cy.getBySelLike("like-count").should("contain", 1);
     cy.getBySelLike("like-button").should("be.disabled");
-    cy.percySnapshot("Transaction after Liked");
+    cy.visualSnapshot("Transaction after Liked");
   });
 
   it("comments on a transaction", function () {
@@ -69,7 +69,7 @@ describe("Transaction View", function () {
     });
 
     cy.getBySelLike("comments-list").children().should("have.length", comments.length);
-    cy.percySnapshot("Comment on Transaction");
+    cy.visualSnapshot("Comment on Transaction");
   });
 
   it("accepts a transaction request", function () {
@@ -79,7 +79,7 @@ describe("Transaction View", function () {
     cy.getBySelLike("accept-request").click();
     cy.wait("@updateTransaction").should("have.property", "status", 204);
     cy.getBySelLike("accept-request").should("not.exist");
-    cy.percySnapshot("Transaction Accepted");
+    cy.visualSnapshot("Transaction Accepted");
   });
 
   it("rejects a transaction request", function () {
@@ -89,7 +89,7 @@ describe("Transaction View", function () {
     cy.getBySelLike("reject-request").click();
     cy.wait("@updateTransaction").should("have.property", "status", 204);
     cy.getBySelLike("reject-request").should("not.exist");
-    cy.percySnapshot("Transaction Rejected");
+    cy.visualSnapshot("Transaction Rejected");
   });
 
   it("does not display accept/reject buttons on completed request", function () {
@@ -104,7 +104,7 @@ describe("Transaction View", function () {
       cy.getBySel("transaction-detail-header").should("be.visible");
       cy.getBySel("transaction-accept-request").should("not.exist");
       cy.getBySel("transaction-reject-request").should("not.exist");
-      cy.percySnapshot("Transaction Completed (not able to accept or reject)");
+      cy.visualSnapshot("Transaction Completed (not able to accept or reject)");
     });
   });
 });

--- a/cypress/tests/ui/user-settings.spec.ts
+++ b/cypress/tests/ui/user-settings.spec.ts
@@ -25,7 +25,7 @@ describe("User Settings", function () {
     cy.getBySel("user-settings-form").should("be.visible");
     cy.location("pathname").should("include", "/user/settings");
 
-    cy.percySnapshot("User Settings Form");
+    cy.visualSnapshot("User Settings Form");
   });
 
   it("should display user setting form errors", function () {
@@ -57,7 +57,7 @@ describe("User Settings", function () {
       .and("contain", "Phone number is not valid");
 
     cy.getBySelLike("submit").should("be.disabled");
-    cy.percySnapshot("User Settings Form Errors and Submit Disabled");
+    cy.visualSnapshot("User Settings Form Errors and Submit Disabled");
   });
 
   it("updates first name, last name, email and phone number", function () {
@@ -76,6 +76,6 @@ describe("User Settings", function () {
     }
 
     cy.getBySel("sidenav-user-full-name").should("contain", "New First Name");
-    cy.percySnapshot("User Settings Update Profile");
+    cy.visualSnapshot("User Settings Update Profile");
   });
 });


### PR DESCRIPTION
Moving to this technique will prevent duplicate snapshots based on "simple" snapshot names (e.g. "Switch to User A"), which can cause visual regression failures if repeated throughout the codebase.

This solution uses the [Mocha's fullTitle()](https://mochajs.org/api/suite#fullTitle) as a prefix to the snapshot name.

via https://github.com/bahmutov/sudoku-qafest/blob/main/cypress/support/index.js#L9

custom command to make taking snapshots with full name
formed from the test title + suffix easier
cy.visualSnapshot() // default full test title
cy.visualSnapshot('clicked') // full test title + ' - clicked'
also sets the width and height to the current viewport