### PR TITLE
Disable Windows Defender for Windows Orb per CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,11 @@ windows-workflow: &windows-workflow
           name: win/default
           shell: bash.exe
           size: large
+        pre-steps:
+          - run:
+              name: Disabling Windows Defender
+              shell: powershell.exe
+              command: Set-MpPreference -DisableRealtimeMonitoring $true
         post-steps:
           - run:
               name: Cypress info


### PR DESCRIPTION
This resolves a recent change in the CircleCI Windows Orb causing the persist to workspace feature to take around 15 minutes.