### PR TITLE
The command 'visualSnapshot' returns an error when called without an argument.

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -38,7 +38,7 @@ declare namespace Cypress {
     /**
      * Custom command to make taking Percy snapshots with full name formed from the test title + suffix easier
      */
-    visualSnapshot(maybeName): Chainable<any>;
+    visualSnapshot(maybeName?): Chainable<any>;
 
     getBySel(dataTestAttribute: string, args?: any): Chainable<Element>;
     getBySelLike(dataTestPrefixAttribute: string, args?: any): Chainable<Element>;


### PR DESCRIPTION
The command 'visualSnapshot' returns an error when called without an argument:
https://i.imgur.com/7a5moR7.png

Making the parameter optional in `global.d.ts` fixes the issue.
https://i.imgur.com/ahGWwqH.png
https://i.imgur.com/SIFyI5b.png

The implementation implies that the argument should be optional.
https://i.imgur.com/bvmATHH.png