### PR TITLE
Remove now-redundant ts-ignore on autoEnd

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -127,7 +127,6 @@ Cypress.Commands.add("loginByXstate", (username, password = Cypress.env("default
     name: "loginbyxstate",
     displayName: "LOGIN BY XSTATE",
     message: [`🔐 Authenticating | ${username}`],
-    // @ts-ignore
     autoEnd: false,
   });
 


### PR DESCRIPTION
I added this to the type definitions in https://github.com/cypress-io/cypress/pull/15076 which was released in 6.5.0 which the project already uses