### PR TITLE
refactor: custom definitions to follow Bitbucket Pipelines yaml Schema

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,50 +1,56 @@
 image: cypress/browsers:node14.15.0-chrome86-ff82
 
-api-tests: &api-tests
-  name: "API Tests"
+definitions:
   caches:
-    - cypress
-    - node
-  script:
-    - yarn start:ci & npx wait-on http://localhost:3000
-    - npx cypress run --record --parallel --browser chrome --group "API" --spec "cypress/tests/api/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
+    yarn: $HOME/.cache
+    cypress: $HOME/.cache/Cypress
 
-ui-chrome-tests: &ui-chrome-tests
-  name: "UI Tests - Chrome"
-  caches:
-    - cypress
-    - node
-  script:
-    - yarn start:ci & npx wait-on http://localhost:3000
-    - npx cypress run --record --parallel --browser chrome --group "UI - Chrome" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
+  steps:
+    - step: &api-tests
+        name: "API Tests"
+        caches:
+          - cypress
+          - node
+        script:
+          - yarn start:ci & npx wait-on http://localhost:3000
+          - npx cypress run --record --parallel --browser chrome --group "API" --spec "cypress/tests/api/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
 
-ui-chrome-tests-mobile: &ui-chrome-tests-mobile
-  name: "UI Tests - Chrome - Mobile"
-  caches:
-    - cypress
-    - node
-  script:
-    - yarn start:ci & npx wait-on http://localhost:3000
-    - npx cypress run --record --parallel --browser chrome --group "UI - Chrome - Mobile" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER --config "viewportWidth=375,viewportHeight=667"
+    - step: &ui-chrome-tests
+        name: "UI Tests - Chrome"
+        caches:
+          - cypress
+          - node
+        script:
+          - yarn start:ci & npx wait-on http://localhost:3000
+          - npx cypress run --record --parallel --browser chrome --group "UI - Chrome" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
 
-ui-firefox-tests: &ui-firefox-tests
-  name: "UI Tests - Firefox"
-  caches:
-    - cypress
-    - node
-  script:
-    - yarn start:ci & npx wait-on http://localhost:3000
-    - npx cypress run --record --parallel --browser firefox --group "UI - Firefox" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
+    - step: &ui-chrome-tests-mobile
+        name: "UI Tests - Chrome - Mobile"
+        caches:
+          - cypress
+          - node
+        script:
+          - yarn start:ci & npx wait-on http://localhost:3000
+          - npx cypress run --record --parallel --browser chrome --group "UI - Chrome - Mobile" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER --config "viewportWidth=375,viewportHeight=667"
 
-ui-firefox-tests-mobile: &ui-firefox-tests-mobile
-  name: "UI Tests - Firefox - Mobile"
-  caches:
-    - cypress
-    - node
-  script:
-    - yarn start:ci & npx wait-on http://localhost:3000
-    - npx cypress run --record --parallel --browser firefox --group "UI - Firefox - Mobile" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER --config "viewportWidth=375,viewportHeight=667"
-    
+    - step: &ui-firefox-tests
+        name: "UI Tests - Firefox"
+        caches:
+          - cypress
+          - node
+        script:
+          - yarn start:ci & npx wait-on http://localhost:3000
+          - npx cypress run --record --parallel --browser firefox --group "UI - Firefox" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER
+
+    - step: &ui-firefox-tests-mobile
+        name: "UI Tests - Firefox - Mobile"
+        caches:
+          - cypress
+          - node
+        script:
+          - yarn start:ci & npx wait-on http://localhost:3000
+          - npx cypress run --record --parallel --browser firefox --group "UI - Firefox - Mobile" --spec "cypress/tests/ui/*" --ci-build-id $BITBUCKET_BUILD_NUMBER --config "viewportWidth=375,viewportHeight=667"
+
 pipelines:
   default:
   - step:
@@ -61,49 +67,24 @@ pipelines:
       artifacts:
         - build/**
   - parallel:
-    - step:
-        <<: *api-tests
-    - step:
-        <<: *ui-chrome-tests
-    - step:
-        <<: *ui-chrome-tests
-    - step:
-        <<: *ui-chrome-tests
-    - step:
-        <<: *ui-chrome-tests
-    - step:
-        <<: *ui-chrome-tests
-    - step:
-        <<: *ui-chrome-tests-mobile
-    - step:
-        <<: *ui-chrome-tests-mobile
-    - step:
-        <<: *ui-chrome-tests-mobile
-    - step:
-        <<: *ui-chrome-tests-mobile
-    - step:
-        <<: *ui-chrome-tests-mobile
-    - step:
-        <<: *ui-firefox-tests
-    - step:
-        <<: *ui-firefox-tests
-    - step:
-        <<: *ui-firefox-tests
-    - step:
-        <<: *ui-firefox-tests
-    - step:
-        <<: *ui-firefox-tests
-    - step:
-        <<: *ui-firefox-tests-mobile
-    - step:
-        <<: *ui-firefox-tests-mobile
-    - step:
-        <<: *ui-firefox-tests-mobile
-    - step:
-        <<: *ui-firefox-tests-mobile
-    - step:
-        <<: *ui-firefox-tests-mobile
-definitions:
-  caches:
-    yarn: $HOME/.cache
-    cypress: $HOME/.cache/Cypress
+    - step: *api-tests
+    - step: *ui-chrome-tests
+    - step: *ui-chrome-tests
+    - step: *ui-chrome-tests
+    - step: *ui-chrome-tests
+    - step: *ui-chrome-tests
+    - step: *ui-chrome-tests-mobile
+    - step: *ui-chrome-tests-mobile
+    - step: *ui-chrome-tests-mobile
+    - step: *ui-chrome-tests-mobile
+    - step: *ui-chrome-tests-mobile
+    - step: *ui-firefox-tests
+    - step: *ui-firefox-tests
+    - step: *ui-firefox-tests
+    - step: *ui-firefox-tests
+    - step: *ui-firefox-tests
+    - step: *ui-firefox-tests-mobile
+    - step: *ui-firefox-tests-mobile
+    - step: *ui-firefox-tests-mobile
+    - step: *ui-firefox-tests-mobile
+    - step: *ui-firefox-tests-mobile


### PR DESCRIPTION
Errors displayed when editing the `bitbucket-pipelines.yaml` file in an IDE with a sample error below:
`Property api-tests is not allowed. yaml-schema: Bitbucket Pipelines Schema`
<img width="710" alt="error on yaml-schema" src="https://user-images.githubusercontent.com/36245304/113133763-c0478280-926b-11eb-8b05-d16f38e84022.png">

Re-structured the custom definitions (e.g. api-tests, ui-firefox-tests, etc.) under **definitions > steps > step** to follow the yaml-schema for Bitbucket Pipeline. 🚀