### PR TITLE
Upgrade @cypress/code-coverage now that Cypress.moment is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@okta/okta-auth-js": "4.8.0",
     "@okta/okta-react": "4.1.0",
     "@xstate/react": "1.3.1",
-    "axios": "0.21.1",
     "aws-amplify": "3.3.26",
+    "axios": "0.21.1",
     "clsx": "1.1.1",
     "date-fns": "2.19.0",
     "dinero.js": "1.8.1",
@@ -45,7 +45,7 @@
     "yup": "0.32.9"
   },
   "devDependencies": {
-    "@cypress/code-coverage": "3.9.4",
+    "@cypress/code-coverage": "^3.9.4",
     "@cypress/instrument-cra": "1.4.0",
     "@percy/cypress": "2.3.4",
     "@types/bcryptjs": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,7 +3356,7 @@
     through2 "^2.0.0"
     watchify "3.11.1"
 
-"@cypress/code-coverage@3.9.4":
+"@cypress/code-coverage@^3.9.4":
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/@cypress/code-coverage/-/code-coverage-3.9.4.tgz#1e82b7061d7b136a99b464e2730d4cf40167bac9"
   integrity sha512-mFUl1MmfqeQe08eONKnAv9uWXRVW2RprqaYf3lJkI5tEhEAP+I9zB+cmjQWKe15vfmadKxqaLStVNYLM0rpYGA==


### PR DESCRIPTION
@cypress/code-coverage used to use Cypress.moment but has since been updated in preparation for 7.X

https://github.com/cypress-io/code-coverage/pull/388