### PR TITLE
Update to Codecov 1.2.1 orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   cypress: cypress-io/cypress@1.28.0
-  codecov: codecov/codecov@1.1.3
+  codecov: codecov/codecov@1.2.1
   win: circleci/windows@2.4.0
 
 executors:
@@ -15,12 +15,17 @@ commands:
   report-coverage:
     description: |
       Store coverage report as an artifact and send it to Codecov service.
+    parameters:
+      using_windows:
+        type: boolean
+        default: true
     steps:
       - store_artifacts:
           path: coverage
       - run: npx nyc report --reporter=text || true
       - codecov/upload:
           file: coverage/coverage-final.json
+          using_windows: << parameters.using_windows>
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 linux-workflow: &linux-workflow
@@ -197,6 +202,7 @@ windows-workflow: &windows-workflow
           - Setup Windows
         post-steps:
           - report-coverage
+              using_windows: true
         no-workspace: true
         timeout: 30m
 


### PR DESCRIPTION
FYI @kevinold 

Migrates to use the `1.2.1` version of the Codecov orb. Also uses the `using_windows` parameter to specify Windows builds

Overwrites https://github.com/cypress-io/cypress-realworld-app/pull/956