### PR TITLE
DX-423 minor login-related cleanup

### DIFF
--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -129,7 +129,7 @@ declare namespace Cypress {
     /**
      * Switch current user by logging out current user and logging as user with specified username
      */
-    switchUser(username: string): Chainable<any>;
+    switchUserByXstate(username: string): Chainable<any>;
 
     /**
      * Create Transaction via bypassing UI and using XState createTransactionService

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -29,6 +29,10 @@ declare namespace Cypress {
     query: object | [object];
   };
 
+  type LoginOptions = {
+    rememberUser: boolean;
+  };
+
   interface Chainable {
     /**
      *  Window object with additional properties used during test.
@@ -94,7 +98,7 @@ declare namespace Cypress {
     /**
      * Logs-in user by using UI
      */
-    login(username: string, password: string, rememberUser?: boolean): void;
+    login(username: string, password: string, loginOptions?: LoginOptions): void;
 
     /**
      * Logs-in user by using API request

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -162,8 +162,6 @@ Cypress.Commands.add("loginByXstate", (username, password = Cypress.env("default
 });
 
 Cypress.Commands.add("logoutByXstate", () => {
-  cy.intercept("POST", "/logout").as("logoutUser");
-
   const log = Cypress.log({
     name: "logoutByXstate",
     displayName: "LOGOUT BY XSTATE",
@@ -177,15 +175,17 @@ Cypress.Commands.add("logoutByXstate", () => {
     win.authService.send("LOGOUT");
   });
 
-  return cy.wait("@logoutUser").then(() => {
-    log.snapshot("after");
-    log.end();
-  });
+  return cy
+    .location("pathname")
+    .should("equal", "/signin")
+    .then(() => {
+      log.snapshot("after");
+      log.end();
+    });
 });
 
 Cypress.Commands.add("switchUserByXstate", (username) => {
   cy.logoutByXstate();
-  cy.location("pathname").should("equal", "/signin");
   return cy.loginByXstate(username).then(() => {
     if (isMobile()) {
       cy.getBySel("sidenav-toggle").click();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -40,7 +40,7 @@ Cypress.Commands.add("getBySelLike", (selector, ...args) => {
   return cy.get(`[data-test*=${selector}]`, ...args);
 });
 
-Cypress.Commands.add("login", (username, password, rememberUser = false) => {
+Cypress.Commands.add("login", (username, password, { rememberUser = false } = {}) => {
   const signinPath = "/signin";
   const log = Cypress.log({
     name: "login",

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -183,7 +183,7 @@ Cypress.Commands.add("logoutByXstate", () => {
   });
 });
 
-Cypress.Commands.add("switchUser", (username) => {
+Cypress.Commands.add("switchUserByXstate", (username) => {
   cy.logoutByXstate();
   cy.location("pathname").should("equal", "/signin");
   return cy.loginByXstate(username).then(() => {

--- a/cypress/tests/demo/cypress-studio.spec.ts
+++ b/cypress/tests/demo/cypress-studio.spec.ts
@@ -5,7 +5,7 @@ describe("Cypress Studio Demo", function () {
     cy.task("db:seed");
 
     cy.database("find", "users").then((user: User) => {
-      cy.login(user.username, "s3cret", true);
+      cy.login(user.username, "s3cret", { rememberUser: true });
     });
   });
   it("create new transaction", function () {

--- a/cypress/tests/ui/auth.spec.ts
+++ b/cypress/tests/ui/auth.spec.ts
@@ -25,14 +25,14 @@ describe("User Sign-up and Login", function () {
 
   it("should redirect to the home page after login", function () {
     cy.database("find", "users").then((user: User) => {
-      cy.login(user.username, "s3cret", true);
+      cy.login(user.username, "s3cret", { rememberUser: true });
     });
     cy.location("pathname").should("equal", "/");
   });
 
   it("should remember a user for 30 days after login", function () {
     cy.database("find", "users").then((user: User) => {
-      cy.login(user.username, "s3cret", true);
+      cy.login(user.username, "s3cret", { rememberUser: true });
     });
 
     // Verify Session Cookie

--- a/cypress/tests/ui/auth.spec.ts
+++ b/cypress/tests/ui/auth.spec.ts
@@ -23,6 +23,13 @@ describe("User Sign-up and Login", function () {
     cy.visualSnapshot("Redirect to SignIn");
   });
 
+  it("should redirect to the home page after login", function () {
+    cy.database("find", "users").then((user: User) => {
+      cy.login(user.username, "s3cret", true);
+    });
+    cy.location("pathname").should("equal", "/");
+  });
+
   it("should remember a user for 30 days after login", function () {
     cy.database("find", "users").then((user: User) => {
       cy.login(user.username, "s3cret", true);

--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -177,7 +177,7 @@ describe("New Transaction", function () {
     }
     cy.visualSnapshot("Transaction Payment Submitted Notification");
 
-    cy.switchUser(ctx.contact!.username);
+    cy.switchUserByXstate(ctx.contact!.username);
 
     const updatedAccountBalance = Dinero({
       amount: ctx.contact!.balance + transactionPayload.amount * 100,
@@ -206,7 +206,7 @@ describe("New Transaction", function () {
     cy.getBySel("new-transaction-create-another-transaction").should("be.visible");
     cy.visualSnapshot("receiver - Transaction Payment Submitted Notification");
 
-    cy.switchUser(ctx.contact!.username);
+    cy.switchUserByXstate(ctx.contact!.username);
 
     cy.getBySelLike("personal-tab").click();
 
@@ -228,7 +228,7 @@ describe("New Transaction", function () {
     cy.getBySelLike("transaction-description").should("be.visible");
     cy.visualSnapshot("Accept Transaction Request");
 
-    cy.switchUser(ctx.user!.username);
+    cy.switchUserByXstate(ctx.user!.username);
 
     const updatedAccountBalance = Dinero({
       amount: ctx.user!.balance + transactionPayload.amount * 100,

--- a/cypress/tests/ui/notifications.spec.ts
+++ b/cypress/tests/ui/notifications.spec.ts
@@ -53,7 +53,7 @@ describe("Notifications", function () {
       cy.contains(likesCountSelector, 1);
       cy.visualSnapshot("Like Count Incremented");
 
-      cy.switchUser(ctx.userB.username);
+      cy.switchUserByXstate(ctx.userB.username);
       cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.wait("@getNotifications")
@@ -97,7 +97,7 @@ describe("Notifications", function () {
       cy.contains(likesCountSelector, 1);
       cy.visualSnapshot("Like Count Incremented");
 
-      cy.switchUser(ctx.userA.username);
+      cy.switchUserByXstate(ctx.userA.username);
       cy.visualSnapshot(`Switch to User ${ctx.userA.username}`);
 
       cy.getBySelLike("notifications-link").click();
@@ -113,7 +113,7 @@ describe("Notifications", function () {
         .and("contain", "liked");
       cy.visualSnapshot("User A Notified of User B Like");
 
-      cy.switchUser(ctx.userB.username);
+      cy.switchUserByXstate(ctx.userB.username);
       cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
@@ -142,7 +142,7 @@ describe("Notifications", function () {
 
       cy.wait("@postComment");
 
-      cy.switchUser(ctx.userB.username);
+      cy.switchUserByXstate(ctx.userB.username);
       cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
@@ -171,7 +171,7 @@ describe("Notifications", function () {
 
       cy.wait("@postComment");
 
-      cy.switchUser(ctx.userA.username);
+      cy.switchUserByXstate(ctx.userA.username);
       cy.visualSnapshot("Switch to User A");
       cy.visualSnapshot(`Switch to User ${ctx.userA.username}`);
 
@@ -186,7 +186,7 @@ describe("Notifications", function () {
         .and("contain", "commented");
       cy.visualSnapshot("User A Notified of User C Comment");
 
-      cy.switchUser(ctx.userB.username);
+      cy.switchUserByXstate(ctx.userB.username);
       cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
@@ -211,7 +211,7 @@ describe("Notifications", function () {
       });
       cy.wait("@createTransaction");
 
-      cy.switchUser(ctx.userB.username);
+      cy.switchUserByXstate(ctx.userB.username);
       cy.visualSnapshot(`Switch to User ${ctx.userB.username}`);
 
       cy.getBySelLike("notifications-link").click();
@@ -237,7 +237,7 @@ describe("Notifications", function () {
       });
       cy.wait("@createTransaction");
 
-      cy.switchUser(ctx.userC.username);
+      cy.switchUserByXstate(ctx.userC.username);
       cy.visualSnapshot(`Switch to User ${ctx.userC.username}`);
 
       cy.getBySelLike("notifications-link").click();


### PR DESCRIPTION
I wanted to make a few tweaks before adding anything related to `cy.session`.

- Assert that logging in redirects to the home page 8ddc995
- Rename `switchUser` to `switchUserByXstate` to be a little more clear 98247c2
- Improve readability of `login` custom command cd1f21a
- Refactor `logoutByXstate` to more accurately assert completion 834d8d8