### PR TITLE
Ensure prettier formatting issues fail the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ linux-workflow: &linux-workflow
               name: Check Types
               command: yarn types
           - run:
+              name: Lint Files
+              command: yarn lint
+          - run:
               name: Run Unit Tests
               command: yarn test:unit:ci
 
@@ -173,6 +176,9 @@ windows-workflow: &windows-workflow
           - run:
               name: Check Types
               command: yarn types
+          - run:
+              name: Lint Files
+              command: yarn lint
           - run:
               name: Run Unit Tests
               command: yarn test:unit:ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       - run: yarn cypress info
       - run: node -p 'os.cpus()'
       - run: yarn types
+      - run: yarn lint
       - run: yarn test:unit:ci
       - run: yarn build:ci
 
@@ -41,6 +42,12 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           runTests: false
+      # report machine parameters
+      - run: yarn cypress info
+      - run: node -p 'os.cpus()'
+      - run: yarn types
+      - run: yarn lint
+      - run: yarn test:unit:ci
       - run: yarn build:ci
 
       - name: Save build folder

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,6 +28,8 @@ install:
     # check Cypress binary path and cached versions
     - npx cypress cache path
     - npx cypress cache list
+    - yarn types
+    - yarn lint
     - yarn test:unit:ci
     - yarn build:ci
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
+# Ignore cache directory for GitLab builds
+/cache
+
 data
 build
 coverage

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -56,6 +56,7 @@ pipelines:
         script:
           - yarn install --frozen-lockfile
           - yarn types
+          - yarn lint
           - yarn test:unit:ci
           - yarn build:ci
         artifacts:

--- a/buildspec-types-unit.yml
+++ b/buildspec-types-unit.yml
@@ -7,4 +7,5 @@ phases:
   build:
     commands:
       - yarn types
+      - yarn lint
       - yarn test:unit:ci

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -59,6 +59,9 @@ phases:
       - yarn install --frozen-lockfile
   pre_build:
     commands:
+      - yarn types
+      - yarn lint
+      - yarn test:unit:ci
       - yarn build:ci
   build:
     commands:

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "prestart:ci": "yarn predev:cognito:ci",
     "start:react": "react-scripts -r @cypress/instrument-cra start",
     "start:empty": "cross-env NODE_ENV=development EMPTY_SEED=true concurrently yarn:start:react yarn:start:api:watch",
+    "lint": "eslint && prettier --check \"**/**.{ts,js,tsx}\" \"*.{json,md,yml}\"",
     "list:dev:users": "cat data/database.json | json -a users | json -a id username",
     "types": "tsc --noEmit",
     "precypress:open": "yarn predev:cognito:ci",


### PR DESCRIPTION
* Add a `yarn lint` command into the build to ensure prettier formatting issues fail the build
* Update CI provider build files to be more consistent in general
* Prettier ignores root-level cache directory for GitLab build