### PR TITLE
build: upgrade and migrate to Dinero.js v2

### DIFF
--- a/cypress/tests/ui/new-transaction.spec.ts
+++ b/cypress/tests/ui/new-transaction.spec.ts
@@ -1,4 +1,4 @@
-import Dinero from "dinero.js";
+import { dineroUSD, format } from "utils/transactionUtils";
 import { User } from "../../../src/models";
 import { isMobile } from "../../support/utils";
 
@@ -59,9 +59,9 @@ describe("New Transaction", function () {
       .should("be.visible")
       .and("have.text", "Transaction Submitted!");
 
-    const updatedAccountBalance = Dinero({
-      amount: ctx.user!.balance - parseInt(payment.amount) * 100,
-    }).toFormat();
+    const updatedAccountBalance = format(
+      dineroUSD(ctx.user!.balance - parseInt(payment.amount) * 100)
+    );
 
     if (isMobile()) {
       cy.getBySel("sidenav-toggle").click();
@@ -179,9 +179,9 @@ describe("New Transaction", function () {
 
     cy.switchUserByXstate(ctx.contact!.username);
 
-    const updatedAccountBalance = Dinero({
-      amount: ctx.contact!.balance + transactionPayload.amount * 100,
-    }).toFormat();
+    const updatedAccountBalance = format(
+      dineroUSD(ctx.contact!.balance + transactionPayload.amount * 100)
+    );
 
     if (isMobile()) {
       cy.getBySel("sidenav-toggle").click();
@@ -230,9 +230,9 @@ describe("New Transaction", function () {
 
     cy.switchUserByXstate(ctx.user!.username);
 
-    const updatedAccountBalance = Dinero({
-      amount: ctx.user!.balance + transactionPayload.amount * 100,
-    }).toFormat();
+    const updatedAccountBalance = format(
+      dineroUSD(ctx.user!.balance + transactionPayload.amount * 100)
+    );
 
     if (isMobile()) {
       cy.getBySel("sidenav-toggle").click();

--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -1,4 +1,3 @@
-import Dinero from "dinero.js";
 import {
   User,
   Transaction,
@@ -8,7 +7,7 @@ import {
   TransactionStatus,
 } from "../../../src/models";
 import { addDays, isWithinInterval, startOfDay } from "date-fns";
-import { startOfDayUTC, endOfDayUTC } from "../../../src/utils/transactionUtils";
+import { startOfDayUTC, endOfDayUTC, dineroUSD, format } from "../../../src/utils/transactionUtils";
 import { isMobile } from "../../support/utils";
 
 const { _ } = Cypress;
@@ -112,9 +111,7 @@ describe("Transaction Feed", function () {
           cy.log("🚩Testing a paid payment transaction item");
           cy.contains("[data-test*='transaction-item']", "paid").within(($el) => {
             const transaction = getTransactionFromEl($el);
-            const formattedAmount = Dinero({
-              amount: transaction.amount,
-            }).toFormat();
+            const formattedAmount = format(dineroUSD(transaction.amount));
 
             expect([TransactionStatus.pending, TransactionStatus.complete]).to.include(
               transaction.status
@@ -136,9 +133,7 @@ describe("Transaction Feed", function () {
           cy.log("🚩Testing a charged payment transaction item");
           cy.contains("[data-test*='transaction-item']", "charged").within(($el) => {
             const transaction = getTransactionFromEl($el);
-            const formattedAmount = Dinero({
-              amount: transaction.amount,
-            }).toFormat();
+            const formattedAmount = format(dineroUSD(transaction.amount));
 
             expect(TransactionStatus.complete).to.equal(transaction.status);
 
@@ -152,9 +147,7 @@ describe("Transaction Feed", function () {
           cy.log("🚩Testing a requested payment transaction item");
           cy.contains("[data-test*='transaction-item']", "requested").within(($el) => {
             const transaction = getTransactionFromEl($el);
-            const formattedAmount = Dinero({
-              amount: transaction.amount,
-            }).toFormat();
+            const formattedAmount = format(dineroUSD(transaction.amount));
 
             expect([TransactionStatus.pending, TransactionStatus.complete]).to.include(
               transaction.status

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@auth0/auth0-react": "1.5.0",
     "@aws-amplify/ui-react": "1.2.4",
+    "@dinero.js/currencies": "2.0.0-alpha.6",
     "@material-ui/core": "4.11.3",
     "@material-ui/icons": "4.11.2",
     "@material-ui/lab": "4.0.0-alpha.58",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "axios": "0.21.1",
     "clsx": "1.1.1",
     "date-fns": "2.22.1",
-    "dinero.js": "1.8.1",
+    "dinero.js": "2.0.0-alpha.6",
     "formik": "2.2.9",
     "history": "4.10.1",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3715,6 +3715,25 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
+"@dinero.js/calculator-number@2.0.0-alpha.6":
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@dinero.js/calculator-number/-/calculator-number-2.0.0-alpha.6.tgz#9ed3d733a7914b283e41be05005d2d6512145032"
+  integrity sha512-+nTAemUcZMYvwYQ4s8xn3SlIQPJtz6UD97rs9BMAK4vXTihFIrxlDDiJIXwUgFsSJ/SfNLaVgYAEVNhCratO/w==
+  dependencies:
+    "@dinero.js/core" "2.0.0-alpha.6"
+
+"@dinero.js/core@2.0.0-alpha.6":
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@dinero.js/core/-/core-2.0.0-alpha.6.tgz#d8554033125a9bbc72a3ca98a68363c8b339d293"
+  integrity sha512-AJxNGi9a9+y1Ow2RR4KAGpWxhrrIgtHFkAQOVJOaWT2Js7TcAEWPgyubE4RBKSN0lgS2sMkeB8FfUbaO7Sphdw==
+  dependencies:
+    "@dinero.js/currencies" "2.0.0-alpha.6"
+
+"@dinero.js/currencies@2.0.0-alpha.6":
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/@dinero.js/currencies/-/currencies-2.0.0-alpha.6.tgz#4dc9aea3b32e9eab8cc8bb3a0b3102e9ad876a89"
+  integrity sha512-MLvmLF7B82ntGT3y/qxWga7VTUi/bmfj0e8RxcpphkmzT2qBtmn0fabqf+bSkpLn5Xbnz2yOXo8LAJHul94XpA==
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -8732,10 +8751,14 @@ dijkstrajs@^1.0.1:
   resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.1.tgz#d3cd81221e3ea40742cfcde556d4e99e98ddc71b"
   integrity sha1-082BIh4+pAdCz83lVtTpnpjdxxs=
 
-dinero.js@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/dinero.js/-/dinero.js-1.8.1.tgz#775a647629b4195af9d02f46e9b7fa1fd81e906d"
-  integrity sha512-AQ09MDKonkGUrhBZZFx4tPTVcVJuHJ0VEA73LvcBoBB2eQSi1DbapeXj4wnUUpx1hVnPdyev1xPNnNMGy/Au0g==
+dinero.js@2.0.0-alpha.6:
+  version "2.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/dinero.js/-/dinero.js-2.0.0-alpha.6.tgz#eb22e2e7a6e8d7796838b9ad60f0d5a23db1add4"
+  integrity sha512-rKU2w5AATj7SlPCIAErjuC5iGBW+dM/jes1Sl0loOWlBFIEUbBCcAvk9wLM1/Wg87YbktWdEd+sgTdPxLrA0NA==
+  dependencies:
+    "@dinero.js/calculator-number" "2.0.0-alpha.6"
+    "@dinero.js/core" "2.0.0-alpha.6"
+    "@dinero.js/currencies" "2.0.0-alpha.6"
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Hey Cypress team!

You're using Dinero.js 1.8.1 in this app, and this makes me happy 😊 I recently released Dinero.js v2, which is a lot lighter, safer, and adapted to modern front-end practices.

[**See documentation**](https://v2.dinerojs.com/docs)

I took the liberty to perform the migration based on your usage, and did my best to follow the coding style and practices I observed in the codebase. Please let me know if you need me to change anything, or feel free to amend the PR yourself if you prefer.

**Edit:** Ouch, looks like UI tests are failing, which I believe is due to formatting issues. I wasn't able to test locally because I wasn't entirely sure how I was supposed to log into the app. Does anyone have input on this?