### PR TITLE
Remove container from install step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   install:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome88-ff89
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I might be wrong, but I don't think the container is necessary to be used in the install step since no tests are running and no browser is needed.

I've tested this with my repository and it reduced the run time for this step by 15-20s.