### PR TITLE
WIP: Cypress v.10 Binary Updated & baseUrl moved in config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node16.13.0-chrome95-ff94
-      options: --user 1001
+      options: --user node
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           runTests: false
       # report machine parameters
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           runTests: false
       # report machine parameters
@@ -92,7 +92,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -136,7 +136,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -182,7 +182,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -227,7 +227,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -270,7 +270,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@3
+        uses: cypress-io/github-action@3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           runTests: false
       # report machine parameters
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           runTests: false
       # report machine parameters
@@ -92,7 +92,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -136,7 +136,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -182,7 +182,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -227,7 +227,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -270,7 +270,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@runs-node16
+        uses: cypress-io/github-action@3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node16.13.0-chrome95-ff94
-      options: --user node
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,6 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: "cypress:server:args"
 
   ui-chrome-mobile-tests:
     timeout-minutes: 15

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   install:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.13.0-chrome95-ff94
+    container:
+      image: cypress/browsers:node16.13.0-chrome95-ff94
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           runTests: false
       # report machine parameters
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           runTests: false
       # report machine parameters
@@ -92,7 +92,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -136,7 +136,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -182,7 +182,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -227,7 +227,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -270,7 +270,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@v3.0.0
+        uses: cypress-io/github-action@v3
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,11 @@ jobs:
     container:
       image: cypress/browsers:node16.13.0-chrome95-ff94
       options: --user 1001
-      - run: ls -la /github/home
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - run: ls -la /github/home
 
       - name: Cypress install
         uses: cypress-io/github-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           runTests: false
       # report machine parameters
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cypress install
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           runTests: false
       # report machine parameters
@@ -92,7 +92,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -136,7 +136,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -182,7 +182,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -227,7 +227,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -270,7 +270,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@3.0.0
+        uses: cypress-io/github-action@v3.0.0
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,34 @@ jobs:
           if-no-files-found: error
           path: build
 
+  component-tests:
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node16.13.0-chrome95-ff94
+    needs: install
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download the build folders
+        uses: actions/download-artifact@v2
+        with:
+          name: build
+          path: build
+
+      - name: "Component Tests"
+        uses: cypress-io/github-action@v3
+        with:
+          start: yarn cypress:run:component
+          browser: chrome
+          record: true
+          group: "Component"
+          spec: src/components/*
+          config-file: cypress.config.js
+        env:
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -84,15 +112,6 @@ jobs:
         with:
           name: build
           path: build
-
-      - name: Cypress info
-        run: npx cypress info
-
-      - name: Node info
-        run: node -v
-
-      - name: __e Dir
-        run: ls /__e
 
       - name: "UI Tests - Chrome"
         uses: cypress-io/github-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: ls -la /github/home
 
       - name: Cypress install
         uses: cypress-io/github-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     container:
       image: cypress/browsers:node16.13.0-chrome95-ff94
       options: --user 1001
+      - run: ls -la /github/home
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -45,7 +45,7 @@ module.exports = defineConfig({
     // Amazon Cognito
     cognito_username: process.env.AWS_COGNITO_USERNAME,
     cognito_password: process.env.AWS_COGNITO_PASSWORD,
-    awsConfig: awsConfig.default,
+    // awsConfig: awsConfig.default,
 
     // Google
     googleRefreshToken: process.env.GOOGLE_REFRESH_TOKEN,

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,10 +11,9 @@ const { devServer } = require("@cypress/react/plugins/react-scripts");
 dotenv.config({ path: ".env.local" });
 dotenv.config();
 
-const awsConfig = require(path.join(__dirname, "./aws-exports-es5.js"));
+// const awsConfig = require(path.join(__dirname, "./aws-exports-es5.js"));
 
 module.exports = defineConfig({
-  //nodeVersion: "system",
   projectId: "7s5okt",
   integrationFolder: "cypress/tests",
   env: {

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,7 +15,6 @@ const awsConfig = require(path.join(__dirname, "./aws-exports-es5.js"));
 
 module.exports = defineConfig({
   //nodeVersion: "system",
-  baseUrl: "http://localhost:3000",
   projectId: "7s5okt",
   integrationFolder: "cypress/tests",
   env: {
@@ -60,6 +59,7 @@ module.exports = defineConfig({
     supportFile: "cypress/support/component.ts",
   },
   e2e: {
+    baseUrl: "http://localhost:3000",
     specPattern: "cypress/tests/**/*.spec.{js,jsx,ts,tsx}",
     supportFile: "cypress/support/e2e.ts",
     viewportHeight: 1000,

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "test:api": "yarn cypress:run --spec 'cypress/tests/api/*'",
     "test:unit": "react-scripts test --runInBand",
     "test:unit:ci": "react-scripts test --watchAll false --ci --runInBand",
-    "test:component:ci": "yarn cypress:run:component --record --group Component",
+    "test:component:ci": "yarn cypress:run:component --record --group Component --parallel",
     "start:api": "yarn tsnode --files backend/app.ts",
     "start:api:watch": "nodemon --exec yarn tsnode --watch 'backend' backend/app.ts",
     "start:react:proxy-server": "yarn tsnode scripts/testServer.ts",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "concurrently": "6.3.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
-    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/linux-x64/circle-10.0-release-83ffb07a10b0392eb23e1fb0b82082ac9fbbd1e9/cypress.tgz",
+    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-d3a8744f1997a82c323af8127f5c9a685021243e/cypress.tgz",
     "dotenv": "10.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "concurrently": "6.3.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
-    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-d3a8744f1997a82c323af8127f5c9a685021243e/cypress.tgz",
+    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/linux-x64/circle-10.0-release-83ffb07a10b0392eb23e1fb0b82082ac9fbbd1e9/cypress.tgz",
     "dotenv": "10.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "concurrently": "6.3.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
-    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz",
+    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz",
     "dotenv": "10.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "concurrently": "6.3.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
-    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-0e544287f6bd5753fec9d8d2b30b15e37154269c/cypress.tgz",
+    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz",
     "dotenv": "10.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "concurrently": "6.3.0",
     "cors": "2.8.5",
     "cross-env": "7.0.3",
-    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz",
+    "cypress": "https://cdn.cypress.io/beta/npm/10.0.0/linux-x64/circle-10.0-release-83ffb07a10b0392eb23e1fb0b82082ac9fbbd1e9/cypress.tgz",
     "dotenv": "10.0.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-cypress": "2.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7690,9 +7690,9 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-"cypress@https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz":
+"cypress@https://cdn.cypress.io/beta/npm/10.0.0/linux-x64/circle-10.0-release-83ffb07a10b0392eb23e1fb0b82082ac9fbbd1e9/cypress.tgz":
   version "10.0.0"
-  resolved "https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz#f0e00351c6970c09fe6452d2749121dc769e33c4"
+  resolved "https://cdn.cypress.io/beta/npm/10.0.0/linux-x64/circle-10.0-release-83ffb07a10b0392eb23e1fb0b82082ac9fbbd1e9/cypress.tgz#9680e0f0361d1ab40a45107b5b60e7a5509fda2a"
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4794,10 +4794,10 @@
   resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
   integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
 
-"@types/sinonjs__fake-timers@^6.0.2":
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz#0ecc1b9259b76598ef01942f547904ce61a6a77d"
-  integrity sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==
+"@types/sinonjs__fake-timers@8.1.1":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
+  integrity sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==
 
 "@types/sizzle@^2.3.2":
   version "2.3.3"
@@ -6859,15 +6859,14 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-table3@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
-  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+cli-table3@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.1.tgz#36ce9b7af4847f288d3cdd081fbd09bf7bd237b8"
+  integrity sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==
   dependencies:
-    object-assign "^4.1.0"
     string-width "^4.2.0"
   optionalDependencies:
-    colors "^1.1.2"
+    colors "1.4.0"
 
 cli-truncate@^2.1.0:
   version "2.1.0"
@@ -7050,7 +7049,7 @@ colorette@^1.2.1, colorette@^1.2.2, colorette@^1.3.0, colorette@^1.4.0:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
 
-colors@^1.1.2, colors@^1.2.1, colors@^1.3.2:
+colors@1.4.0, colors@^1.2.1, colors@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -7691,14 +7690,14 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-"cypress@https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-0e544287f6bd5753fec9d8d2b30b15e37154269c/cypress.tgz":
+"cypress@https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz":
   version "10.0.0"
-  resolved "https://cdn.cypress.io/beta/npm/10.0.0/circle-10.0-release-0e544287f6bd5753fec9d8d2b30b15e37154269c/cypress.tgz#311837488187be4c7878d4cbc7c8a7422244dbc3"
+  resolved "https://cdn.cypress.io/beta/npm/10.0.0/darwin-x64/circle-10.0-release-bb37389157d85c79db81a0c2e37ac10d3a13b37b/cypress.tgz#f0e00351c6970c09fe6452d2749121dc769e33c4"
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^14.14.31"
-    "@types/sinonjs__fake-timers" "^6.0.2"
+    "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
     blob-util "^2.0.2"
@@ -7708,7 +7707,7 @@ cyclist@^1.0.1:
     chalk "^4.1.0"
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
-    cli-table3 "~0.6.0"
+    cli-table3 "~0.6.1"
     commander "^5.1.0"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
@@ -7732,10 +7731,10 @@ cyclist@^1.0.1:
     pretty-bytes "^5.6.0"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
+    semver "^7.3.2"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
-    url "^0.11.0"
     yauzl "^2.10.0"
 
 d@1, d@^1.0.1:


### PR DESCRIPTION
- Installed the latest Cypress binary as the version currently referenced returns a 404
- Moved the `baseUrl` under the `e2e` section of the `cypress.config.js` file
- Update `cypress-io/github-action@v3` in GHA config to use the latest version