### PR TITLE
Update `cypress.config.ts` for config migration

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  projectId: '7s5okt',
+  viewportHeight: 1000,
+  viewportWidth: 1280,
+  retries: {
+    runMode: 2,
+    openMode: 1,
+  },
+  env: {
+    apiUrl: 'http://localhost:3001',
+    mobileViewportWidthBreakpoint: 414,
+    coverage: false,
+    codeCoverage: {
+      url: 'http://localhost:3001/__coverage__',
+    },
+  },
+  experimentalStudio: true,
+  e2e: {
+    // We've imported your old cypress plugins here.
+    // You may want to clean this up later by importing these.
+    setupNodeEvents(on, config) {
+      return require('./cypress/plugins/index.ts').default(on, config)
+    },
+    baseUrl: 'http://localhost:3000',
+    specPattern: 'cypress/tests/**/*.cy.{js,jsx,ts,tsx}',
+  },
+})


### PR DESCRIPTION
Closes UNIFY-1073

Starting E2E for the first time after migrating RWA is broken because our `cypress.config.ts` file uses require and synchronous imports. This PR updates the config template.

