### PR TITLE
fix: cypress error when running at auth0 mode

### DIFF
--- a/cypress/tests/ui-auth-providers/auth0.spec.ts
+++ b/cypress/tests/ui-auth-providers/auth0.spec.ts
@@ -5,8 +5,7 @@ if (Cypress.env("auth0_client_id")) {
     beforeEach(function () {
       cy.task("db:seed");
 
-      cy.server();
-      cy.route("POST", "/bankAccounts").as("createBankAccount");
+      cy.route("POST", "/graphql").as("createBankAccount");
 
       cy.loginByAuth0Api(Cypress.env("auth0_username"), Cypress.env("auth0_password"));
     });


### PR DESCRIPTION
closes #1220
<img width="1296" alt="Screen Shot 2022-03-24 at 23 52 45" src="https://user-images.githubusercontent.com/1336862/160016528-f3ce7f0c-3298-4817-aedb-2c46ff5337eb.png">
noticed that instead of "/bankAccount", the actual request url Is "/graphql"