### PR TITLE
chore: remove use of server and route

### DIFF
--- a/cypress/tests/ui-auth-providers/auth0.spec.ts
+++ b/cypress/tests/ui-auth-providers/auth0.spec.ts
@@ -5,7 +5,7 @@ if (Cypress.env("auth0_client_id")) {
     beforeEach(function () {
       cy.task("db:seed");
 
-      cy.route("POST", "/graphql").as("createBankAccount");
+      cy.intercept("POST", "/graphql").as("createBankAccount");
 
       cy.loginByAuth0Api(Cypress.env("auth0_username"), Cypress.env("auth0_password"));
     });

--- a/cypress/tests/ui-auth-providers/cognito.spec.ts
+++ b/cypress/tests/ui-auth-providers/cognito.spec.ts
@@ -6,8 +6,7 @@ if (Cypress.env("cognito_username")) {
     beforeEach(function () {
       cy.task("db:seed");
 
-      cy.server();
-      cy.route("POST", "/bankAccounts").as("createBankAccount");
+      cy.intercept("POST", "/bankAccounts").as("createBankAccount");
 
       cy.loginByCognitoApi(Cypress.env("cognito_username"), Cypress.env("cognito_password"));
     });

--- a/cypress/tests/ui-auth-providers/google.spec.ts
+++ b/cypress/tests/ui-auth-providers/google.spec.ts
@@ -5,8 +5,7 @@ if (Cypress.env("googleClientId")) {
     beforeEach(function () {
       cy.task("db:seed");
 
-      cy.server();
-      cy.route("POST", "/bankAccounts").as("createBankAccount");
+      cy.intercept("POST", "/bankAccounts").as("createBankAccount");
 
       cy.loginByGoogleApi();
     });

--- a/cypress/tests/ui-auth-providers/okta.spec.ts
+++ b/cypress/tests/ui-auth-providers/okta.spec.ts
@@ -5,8 +5,7 @@ if (Cypress.env("okta_client_id")) {
     beforeEach(function () {
       cy.task("db:seed");
 
-      cy.server();
-      cy.route("POST", "/bankAccounts").as("createBankAccount");
+      cy.intercept("POST", "/bankAccounts").as("createBankAccount");
 
       cy.loginByOktaApi(Cypress.env("okta_username"), Cypress.env("okta_password"));
     });


### PR DESCRIPTION
cy.intercept and cy.server are both going away in 12.0.0. Lets cut to the chase and remove them now!