### PR TITLE
feat: update okta realworld app to allow for cy.origin()

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -37,6 +37,7 @@ module.exports = defineConfig({
     okta_password: process.env.OKTA_PASSWORD,
     okta_domain: process.env.REACT_APP_OKTA_DOMAIN,
     okta_client_id: process.env.REACT_APP_OKTA_CLIENTID,
+    okta_programmatic_login: process.env.OKTA_PROGRAMMATIC_LOGIN || false,
 
     // Amazon Cognito
     cognito_username: process.env.AWS_COGNITO_USERNAME,
@@ -63,7 +64,8 @@ module.exports = defineConfig({
     supportFile: "cypress/support/e2e.ts",
     viewportHeight: 1000,
     viewportWidth: 1280,
-    experimentalSessionAndOrigin: !!process.env.REACT_APP_AUTH0_CLIENTID,
+    experimentalSessionAndOrigin:
+      !!process.env.REACT_APP_AUTH0_CLIENTID || !process.env.OKTA_PROGRAMMATIC_LOGIN,
     setupNodeEvents(on, config) {
       const testDataApiEndpoint = `${config.env.apiUrl}/testData`;
 

--- a/cypress/global.d.ts
+++ b/cypress/global.d.ts
@@ -116,6 +116,11 @@ declare namespace Cypress {
     loginByOktaApi(username: string, password?: string): Chainable<Response>;
 
     /**
+     * Logs-in user by navigating to Okta tenant with cy.origin()
+     */
+    loginByOkta(username: string, password: string): Chainable<Response>;
+
+    /**
      * Logs in bypassing UI by triggering XState login event
      */
     loginByXstate(username: string, password?: string): Chainable<any>;

--- a/cypress/support/auth-provider-commands/okta.ts
+++ b/cypress/support/auth-provider-commands/okta.ts
@@ -60,3 +60,40 @@ Cypress.Commands.add("loginByOktaApi", (username: string, password?: string) => 
 
   cy.visit("/");
 });
+
+// Okta
+Cypress.Commands.add("loginByOkta", (username: string, password: string) => {
+  cy.session(
+    `okta-${username}`,
+    () => {
+      Cypress.log({
+        displayName: "OKTA LOGIN",
+        message: [`🔐 Authenticating | ${username}`],
+        // @ts-ignore
+        autoEnd: false,
+      });
+
+      cy.visit("/");
+
+      cy.origin(
+        Cypress.env("okta_domain"),
+        { args: { username, password } },
+        ({ username, password }) => {
+          cy.get('input[name="identifier"]').type(username);
+          cy.get('input[name="credentials.passcode"]').type(password, {
+            log: false,
+          });
+          cy.get('[type="submit"]').click();
+        }
+      );
+
+      cy.get('[data-test="sidenav-username"]').should("contain", username);
+    },
+    {
+      validate() {
+        cy.visit("/");
+        cy.get('[data-test="sidenav-username"]').should("contain", username);
+      },
+    }
+  );
+});

--- a/cypress/support/auth-provider-commands/okta.ts
+++ b/cypress/support/auth-provider-commands/okta.ts
@@ -11,7 +11,6 @@ Cypress.Commands.add("loginByOktaApi", (username: string, password?: string) => 
   const log = Cypress.log({
     displayName: "OKTA LOGIN",
     message: [`🔐 Authenticating | ${username}`],
-    // @ts-ignore
     autoEnd: false,
   });
 
@@ -69,7 +68,6 @@ Cypress.Commands.add("loginByOkta", (username: string, password: string) => {
       Cypress.log({
         displayName: "OKTA LOGIN",
         message: [`🔐 Authenticating | ${username}`],
-        // @ts-ignore
         autoEnd: false,
       });
 

--- a/cypress/support/auth-provider-commands/okta.ts
+++ b/cypress/support/auth-provider-commands/okta.ts
@@ -68,7 +68,6 @@ Cypress.Commands.add("loginByOkta", (username: string, password: string) => {
       Cypress.log({
         displayName: "OKTA LOGIN",
         message: [`🔐 Authenticating | ${username}`],
-        autoEnd: false,
       });
 
       cy.visit("/");

--- a/cypress/tests/ui-auth-providers/okta.spec.ts
+++ b/cypress/tests/ui-auth-providers/okta.spec.ts
@@ -1,6 +1,6 @@
 import { isMobile } from "../../support/utils";
 
-if (Cypress.env("okta_client_id")) {
+if (Cypress.env("okta_programmatic_login")) {
   describe("Okta", function () {
     beforeEach(function () {
       cy.task("db:seed");
@@ -43,6 +43,25 @@ if (Cypress.env("okta_client_id")) {
 
     it("shows onboarding", function () {
       cy.contains("Get Started").should("be.visible");
+    });
+  });
+} else {
+  describe("Okta", function () {
+    beforeEach(function () {
+      cy.task("db:seed");
+
+      cy.loginByOkta(Cypress.env("okta_username"), Cypress.env("okta_password"));
+      cy.visit("/");
+    });
+
+    it("verifies signed in user does not have a bank account", function () {
+      cy.get('[data-test="sidenav-bankaccounts"]').click();
+      cy.get('[data-test="empty-list-header"]').should("be.visible");
+    });
+
+    it("verifies signed in user does not have any notifications", function () {
+      cy.get('[data-test="sidenav-notifications"]').click();
+      cy.get('[data-test="empty-list-header"]').should("be.visible");
     });
   });
 }

--- a/src/containers/AppOkta.tsx
+++ b/src/containers/AppOkta.tsx
@@ -39,7 +39,7 @@ const AppOkta: React.FC = () => {
   const [, , bankAccountsService] = useMachine(bankAccountsMachine);
 
   // @ts-ignore
-  if (window.Cypress) {
+  if (window.Cypress && process.env.REACT_APP_OKTA_PROGRAMMATIC) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const okta = JSON.parse(localStorage.getItem("oktaCypress")!);
@@ -89,6 +89,7 @@ const AppOkta: React.FC = () => {
   );
 };
 
-//@ts-ignore
-let appOkta = window.Cypress ? AppOkta : withOktaAuth(AppOkta);
+let appOkta =
+  //@ts-ignore
+  window.Cypress && process.env.REACT_APP_OKTA_PROGRAMMATIC ? AppOkta : withOktaAuth(AppOkta);
 export default appOkta;


### PR DESCRIPTION
Updates the realworld app to use cy.origin() and cy.session with okta to authenticate and test the realworld app. Docs PR: https://github.com/cypress-io/cypress-documentation/pull/4883