### PR TITLE
fix: wrap okta tests around okta_username var to prevent auth tests r…

### DIFF
--- a/cypress/support/auth-provider-commands/cognito.ts
+++ b/cypress/support/auth-provider-commands/cognito.ts
@@ -92,6 +92,15 @@ Cypress.Commands.add("loginByCognito", (username, password) => {
     {
       validate() {
         cy.visit("/");
+        /**
+         * NOTE: We recommend validating sessions by either validating
+         * localStorage or cookies values, or possibly accessing an
+         * endpoint to validate that the correct user is logged.
+         *
+         * This example is here for brevity to make sure
+         * our user is directly taken to the onboarding flow
+         * and not blocked by a login screen
+         */
         // revalidate our session to make sure we are logged in
         cy.contains("Get Started").should("be.visible");
       },

--- a/cypress/support/auth-provider-commands/okta.ts
+++ b/cypress/support/auth-provider-commands/okta.ts
@@ -89,6 +89,12 @@ Cypress.Commands.add("loginByOkta", (username: string, password: string) => {
     {
       validate() {
         cy.visit("/");
+        /**
+         * NOTE: We recommend validating sessions by either validating
+         * localStorage or cookies values, or possibly accessing an
+         * endpoint to validate that the correct user is logged.
+         */
+        // revalidate our session to make sure we are logged in
         cy.get('[data-test="sidenav-username"]').should("contain", username);
       },
     }

--- a/cypress/tests/ui-auth-providers/okta.spec.ts
+++ b/cypress/tests/ui-auth-providers/okta.spec.ts
@@ -1,67 +1,69 @@
 import { isMobile } from "../../support/utils";
 
-if (Cypress.env("okta_programmatic_login")) {
-  describe("Okta", function () {
-    beforeEach(function () {
-      cy.task("db:seed");
+if (Cypress.env("okta_username")) {
+  if (Cypress.env("okta_programmatic_login")) {
+    describe("Okta", function () {
+      beforeEach(function () {
+        cy.task("db:seed");
 
-      cy.intercept("POST", "/bankAccounts").as("createBankAccount");
+        cy.intercept("POST", "/bankAccounts").as("createBankAccount");
 
-      cy.loginByOktaApi(Cypress.env("okta_username"), Cypress.env("okta_password"));
+        cy.loginByOktaApi(Cypress.env("okta_username"), Cypress.env("okta_password"));
+      });
+
+      it("should allow a visitor to login, onboard and logout", function () {
+        cy.contains("Get Started").should("be.visible");
+
+        // Onboarding
+        cy.getBySel("user-onboarding-dialog").should("be.visible");
+        cy.getBySel("user-onboarding-next").click();
+
+        cy.getBySel("user-onboarding-dialog-title").should("contain", "Create Bank Account");
+
+        cy.getBySelLike("bankName-input").type("The Best Bank");
+        cy.getBySelLike("accountNumber-input").type("123456789");
+        cy.getBySelLike("routingNumber-input").type("987654321");
+        cy.getBySelLike("submit").click();
+
+        cy.wait("@createBankAccount");
+
+        cy.getBySel("user-onboarding-dialog-title").should("contain", "Finished");
+        cy.getBySel("user-onboarding-dialog-content").should("contain", "You're all set!");
+        cy.getBySel("user-onboarding-next").click();
+
+        cy.getBySel("transaction-list").should("be.visible");
+
+        // Logout User
+        if (isMobile()) {
+          cy.getBySel("sidenav-toggle").click();
+        }
+        cy.getBySel("sidenav-signout").click();
+
+        cy.location("pathname").should("eq", "/");
+      });
+
+      it("shows onboarding", function () {
+        cy.contains("Get Started").should("be.visible");
+      });
     });
+  } else {
+    describe("Okta", function () {
+      beforeEach(function () {
+        cy.task("db:seed");
 
-    it("should allow a visitor to login, onboard and logout", function () {
-      cy.contains("Get Started").should("be.visible");
+        cy.loginByOkta(Cypress.env("okta_username"), Cypress.env("okta_password"));
+        cy.visit("/");
+      });
 
-      // Onboarding
-      cy.getBySel("user-onboarding-dialog").should("be.visible");
-      cy.getBySel("user-onboarding-next").click();
+      it("verifies signed in user does not have a bank account", function () {
+        cy.get('[data-test="sidenav-bankaccounts"]').click();
+        cy.get('[data-test="empty-list-header"]').should("be.visible");
+      });
 
-      cy.getBySel("user-onboarding-dialog-title").should("contain", "Create Bank Account");
-
-      cy.getBySelLike("bankName-input").type("The Best Bank");
-      cy.getBySelLike("accountNumber-input").type("123456789");
-      cy.getBySelLike("routingNumber-input").type("987654321");
-      cy.getBySelLike("submit").click();
-
-      cy.wait("@createBankAccount");
-
-      cy.getBySel("user-onboarding-dialog-title").should("contain", "Finished");
-      cy.getBySel("user-onboarding-dialog-content").should("contain", "You're all set!");
-      cy.getBySel("user-onboarding-next").click();
-
-      cy.getBySel("transaction-list").should("be.visible");
-
-      // Logout User
-      if (isMobile()) {
-        cy.getBySel("sidenav-toggle").click();
-      }
-      cy.getBySel("sidenav-signout").click();
-
-      cy.location("pathname").should("eq", "/");
+      it("verifies signed in user does not have any notifications", function () {
+        cy.get('[data-test="sidenav-notifications"]').click();
+        cy.get('[data-test="empty-list-header"]').should("be.visible");
+      });
     });
-
-    it("shows onboarding", function () {
-      cy.contains("Get Started").should("be.visible");
-    });
-  });
-} else {
-  describe("Okta", function () {
-    beforeEach(function () {
-      cy.task("db:seed");
-
-      cy.loginByOkta(Cypress.env("okta_username"), Cypress.env("okta_password"));
-      cy.visit("/");
-    });
-
-    it("verifies signed in user does not have a bank account", function () {
-      cy.get('[data-test="sidenav-bankaccounts"]').click();
-      cy.get('[data-test="empty-list-header"]').should("be.visible");
-    });
-
-    it("verifies signed in user does not have any notifications", function () {
-      cy.get('[data-test="sidenav-notifications"]').click();
-      cy.get('[data-test="empty-list-header"]').should("be.visible");
-    });
-  });
+  }
 }


### PR DESCRIPTION
…unning in cypress-io binary tests

wraps the okta tests in a env variable `okta_username` simialr to the other auth provider tests to prevent these from running in 