### PR TITLE
update Auth0 login command

### DIFF
--- a/cypress/support/auth-provider-commands/auth0.ts
+++ b/cypress/support/auth-provider-commands/auth0.ts
@@ -14,7 +14,7 @@ Cypress.Commands.add("loginToAuth0", (username: string, password: string) => {
 
   const args = { username, password };
   cy.session(
-    args,
+    `auth0-${username}`,
     () => {
       // App landing page redirects to Auth0.
       cy.visit("/");
@@ -32,7 +32,7 @@ Cypress.Commands.add("loginToAuth0", (username: string, password: string) => {
     {
       validate: () => {
         // Validate presence of access token in localStorage.
-        cy.wrap(localStorage).invoke("getItem", "authAccessToken").should("exist");
+        cy.wrap(localStorage).invoke("getItem", "authState").should("exist");
       },
     }
   );

--- a/cypress/support/auth-provider-commands/auth0.ts
+++ b/cypress/support/auth-provider-commands/auth0.ts
@@ -32,7 +32,7 @@ Cypress.Commands.add("loginToAuth0", (username: string, password: string) => {
     {
       validate: () => {
         // Validate presence of access token in localStorage.
-        cy.wrap(localStorage).invoke("getItem", "authState").should("exist");
+        cy.window().its("localStorage").invoke("getItem", "authState").should("exist");
       },
     }
   );


### PR DESCRIPTION
The [session docs](https://docs.cypress.io/api/commands/session#Choosing-the-correct-id-to-cache-a-session) say

> The id provided to cy.session() will display in the reporter, thus we do not recommend using sensitive data like passwords or tokens as unique identifiers.

so I updated the session ID for the Auth0 login to only use the username. I also updated the assertion for local storage because that was always failing for me. I think we should be looking for `authState` instead. The docs also say `authAccessToken` so we might need to update that too (unless I'm doing something wrong).

### How to test
- Set the Auth0 variables in `.env` (ask me or @AtofStryker for credentials)
- run RWA with `yarn dev:auth0`
- launch cypress
- run `auth0.spec.ts`
