### PR TITLE
chore: use React 18 render API

### DIFF
--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -20,7 +20,7 @@ import "./commands";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-import { mount } from "cypress/react";
+import { mount } from "cypress/react18";
 
 Cypress.Commands.add("mount", mount);
 

--- a/src/containers/TransactionsContainer.cy.tsx
+++ b/src/containers/TransactionsContainer.cy.tsx
@@ -35,7 +35,7 @@ describe("Transactions Container", () => {
     cy.get(".MuiListSubheader-root").should("contain", "Contacts");
   });
   it("should render personal transactions", () => {
-    cy.intercept("http://localhost:3001/transactions/*", {
+    cy.intercept("http://localhost:3001/transactions", {
       fixture: "public-transactions.json",
     });
     cy.mount(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { Router } from "react-router-dom";
 import { createMuiTheme, ThemeProvider } from "@material-ui/core";
 import { Auth0Provider } from "@auth0/auth0-react";
@@ -28,9 +28,11 @@ const onRedirectCallback = (appState: any) => {
   history.replace((appState && appState.returnTo) || window.location.pathname);
 };
 
+const root = createRoot(document.getElementById("root"));
+
 /* istanbul ignore if */
 if (process.env.REACT_APP_AUTH0) {
-  ReactDOM.render(
+  root.render(
     <Auth0Provider
       domain={process.env.REACT_APP_AUTH0_DOMAIN!}
       clientId={process.env.REACT_APP_AUTH0_CLIENTID!}
@@ -45,8 +47,7 @@ if (process.env.REACT_APP_AUTH0) {
           <AppAuth0 />
         </ThemeProvider>
       </Router>
-    </Auth0Provider>,
-    document.getElementById("root")
+    </Auth0Provider>
   );
 } else if (process.env.REACT_APP_OKTA) {
   const oktaAuth = new OktaAuth({
@@ -56,43 +57,39 @@ if (process.env.REACT_APP_AUTH0) {
   });
 
   /* istanbul ignore next */
-  ReactDOM.render(
+  root.render(
     <Router history={history}>
       <ThemeProvider theme={theme}>
         <Security oktaAuth={oktaAuth}>
           <AppOkta />
         </Security>
       </ThemeProvider>
-    </Router>,
-    document.getElementById("root")
+    </Router>
   );
 } else if (process.env.REACT_APP_AWS_COGNITO) {
   /* istanbul ignore next */
-  ReactDOM.render(
+  root.render(
     <Router history={history}>
       <ThemeProvider theme={theme}>
         <AppCognito />
       </ThemeProvider>
-    </Router>,
-    document.getElementById("root")
+    </Router>
   );
 } else if (process.env.REACT_APP_GOOGLE) {
   /* istanbul ignore next */
-  ReactDOM.render(
+  root.render(
     <Router history={history}>
       <ThemeProvider theme={theme}>
         <AppGoogle />
       </ThemeProvider>
-    </Router>,
-    document.getElementById("root")
+    </Router>
   );
 } else {
-  ReactDOM.render(
+  root.render(
     <Router history={history}>
       <ThemeProvider theme={theme}>
         <App />
       </ThemeProvider>
-    </Router>,
-    document.getElementById("root")
+    </Router>
   );
 }


### PR DESCRIPTION
We upgraded to React 18 but we are still using `ReactDOM.render` to render our app. 

With React 18 we should now import `createRoot` from `react-dom/client` and use that to create our root. Then we call `render` on the root that we created. More details [here](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis).

**Testing**:
- Start the app and verify that everything renders correctly and there is no warning in the console regarding the use of `ReactDOM.render` in React 18

<img width="767" alt="Screenshot 2023-02-09 at 9 48 53 AM" src="https://user-images.githubusercontent.com/14275198/217882134-9ab52295-a1c6-4b1d-b5cd-3f0aad2c1d77.png">


