### PR TITLE
chore: remove use of deprecated createMuiTheme

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import { Router } from "react-router-dom";
-import { createMuiTheme, ThemeProvider } from "@material-ui/core";
+import { createTheme, ThemeProvider } from "@material-ui/core";
 import { Auth0Provider } from "@auth0/auth0-react";
 /* istanbul ignore next */
 // @ts-ignore
@@ -15,7 +15,7 @@ import AppOkta from "./containers/AppOkta";
 import AppCognito from "./containers/AppCognito";
 import { history } from "./utils/historyUtils";
 
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     secondary: {
       main: "#fff",


### PR DESCRIPTION
`createMuiTheme` is deprecated in favor of `createTheme`. This PR updates the usage to remove this warning

<img width="766" alt="Screenshot 2023-02-09 at 9 59 33 AM" src="https://user-images.githubusercontent.com/14275198/217884841-3bffef08-5db4-4ef8-825a-809f6ae526b0.png">
