### PR TITLE
chore(deps): update cypress-io/github-action to v5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cypress install
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           runTests: false
       # report machine parameters
@@ -42,14 +42,14 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          # The default install for the job is node 18+ 
+          # The default install for the job is node 18+
           # which has some compatibility issues with openSSL inside this windows job.
           # Node 18 updated with OpenSSL provider which causes this compatibility issue
           # downgrading node to v16 to use the openssl-legacy-provider by default to prevent this issue
           node-version: '16'
 
       - name: Cypress install
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           runTests: false
       # report machine parameters
@@ -103,7 +103,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -149,7 +149,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -195,7 +195,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -240,7 +240,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -283,7 +283,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v5
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"


### PR DESCRIPTION
This PR updates [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml) to use the current `cypress-io/github-action@v5` version instead of `cypress-io/github-action@v4` which is no longer maintained.

For reference, the current version is published to GitHub Marketplace as [cypress-io/github-action](https://github.com/marketplace/actions/cypress-io#cypress-iogithub-action--).
