### PR TITLE
docs: add yarn classic to prerequisite list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,23 @@ The app is bundled with [example data](./data/database.json) (`data/database.jso
 
 ### Prerequisites
 
-The only requirement for this project is to have [Node.js](https://nodejs.org/en/) installed on your machine. Refer to the [.node-version](./.node-version) file for the exact version.
+This project requires [Node.js](https://nodejs.org/en/) to be installed on your machine. Refer to the [.node-version](./.node-version) file for the exact version.
+
+[Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute
+
+```bash
+npm install yarn -g
+```
+
+to install the correct version of `yarn`. If you have already installed [Yarn Modern](https://yarnpkg.com/), then execute
+
+```bash
+yarn set version classic
+```
+
+to set the necessary and compatible version.
+
+**The project is not compatible with [Yarn Modern](https://yarnpkg.com/).**
 
 TypeScript will be added as a local dependency to the project, so no need to install it.
 

--- a/README.md
+++ b/README.md
@@ -66,21 +66,19 @@ The app is bundled with [example data](./data/database.json) (`data/database.jso
 
 This project requires [Node.js](https://nodejs.org/en/) to be installed on your machine. Refer to the [.node-version](./.node-version) file for the exact version.
 
-[Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute
+[Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute the following to install the correct version of `yarn`.
 
 ```bash
 npm install yarn -g
 ```
 
-to install the correct version of `yarn`. If you have already installed [Yarn Modern](https://yarnpkg.com/), then execute
+The following command allows you to check that you have Yarn Classic (version 1) installed and active:
 
 ```bash
-yarn set version classic
+yarn -v
 ```
 
-to set the necessary and compatible version.
-
-**The project is not compatible with [Yarn Modern](https://yarnpkg.com/).**
+**This project is not compatible with [Yarn Modern](https://yarnpkg.com/) (version 2 and later).**
 
 TypeScript will be added as a local dependency to the project, so no need to install it.
 


### PR DESCRIPTION
This PR corrects the [README: Prerequisites](https://github.com/cypress-io/cypress-realworld-app/blob/develop/README.md#prerequisites) section by adding Yarn Classic to the list of prerequisites. The app is compatible with Yarn Classic only, not with Yarn Modern. Yarn is not installed by default.

## Prerequisite issue

- Without Yarn installed it is not possible to execute any `yarn` commands.

## Compatibility issue

- If [Yarn Modern](https://yarnpkg.com/) is installed instead of [Yarn Classic](https://classic.yarnpkg.com/), then the backend server fails to start.

- The [yarn.lock](https://github.com/cypress-io/cypress-realworld-app/blob/develop/yarn.lock) file is in `# yarn lockfile v1` format. Executing `yarn` with Yarn Modern migrates the lock file to `version: 6`, reporting `YN0000: Done with warnings`. Then executing `yarn dev` fails with `TSError: ⨯ Unable to compile TypeScript`.

```text
[start:api:watch] [nodemon] starting `yarn tsnode backend/app.ts`
[start:react] [HPM] Proxy created: [ '/login', '/callback', '/logout', '/checkAuth', 'graphql' ]  ->  http://localhost:undefined
[start:react] [HPM] Subscribed to http-proxy events:  [ 'error', 'close' ]
[start:react] ℹ ｢wds｣: Project is running at http://192.168.8.129/
[start:react] ℹ ｢wds｣: webpack output is served from
[start:react] ℹ ｢wds｣: Content not from webpack is served from /home/yarn2/github/cypress.io/cypress-realworld-app/public
[start:react] ℹ ｢wds｣: 404s will fallback to /
[start:react] Starting the development server...
[start:react]
[start:api:watch] /home/yarn2/github/cypress.io/cypress-realworld-app/node_modules/ts-node/src/index.ts:820
[start:api:watch]     return new TSError(diagnosticText, diagnosticCodes);
[start:api:watch]            ^
[start:api:watch] TSError: ⨯ Unable to compile TypeScript:
[start:api:watch] backend/helpers.ts(92,50): error TS2349: This expression is not callable.
[start:api:watch]   Type 'typeof import("/home/yarn2/github/cypress.io/cypress-realworld-app/node_modules/express-unless/dist/index")' has no call signatures.
[start:api:watch] backend/helpers.ts(93,57): error TS2349: This expression is not callable.
[start:api:watch]   Type 'typeof import("/home/yarn2/github/cypress.io/cypress-realworld-app/node_modules/express-unless/dist/index")' has no call signatures.
[start:api:watch] backend/helpers.ts(94,52): error TS2349: This expression is not callable.
[start:api:watch]   Type 'typeof import("/home/yarn2/github/cypress.io/cypress-realworld-app/node_modules/express-unless/dist/index")' has no call signatures.
```

## Changes

Yarn Classic is added to the list of prerequisites.
