### PR TITLE
chore(deps): remove @babel/compat-data lock on 7.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "typescript": "4.6.3"
   },
   "resolutions": {
-    "@babel/compat-data": "7.9.0",
     "@types/express": "4.17.2",
     "@types/express-serve-static-core": "4.17.2"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -26,10 +26,6 @@
       "schedule": ["every weekday"]
     },
     {
-      "packageNames": ["@babel/compat-data"],
-      "allowedVersions": "7.9.0"
-    },
-    {
       "packageNames": ["babel-loader"],
       "allowedVersions": "8.0.6"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,14 +2187,10 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/compat-data@7.9.0", "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.21.5":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.0.tgz#04815556fc90b0c174abd2c0c1bb966faa036a6c"
-  integrity sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==
-  dependencies:
-    browserslist "^4.9.1"
-    invariant "^2.2.4"
-    semver "^5.5.0"
+"@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.5", "@babel/compat-data@^7.21.5":
+  version "7.21.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.21.7.tgz#61caffb60776e49a57ba61a88f02bedd8714f6bc"
+  integrity sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==
 
 "@babel/core@7.12.3":
   version "7.12.3"
@@ -6338,7 +6334,7 @@ browserslist@4.14.2:
     escalade "^3.0.2"
     node-releases "^1.1.61"
 
-browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.21.3, browserslist@^4.21.5, browserslist@^4.6.2, browserslist@^4.6.4, browserslist@^4.9.1:
+browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.21.3, browserslist@^4.21.5, browserslist@^4.6.2, browserslist@^4.6.4:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
   integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
@@ -10478,13 +10474,6 @@ internal-slot@^1.0.3, internal-slot@^1.0.4, internal-slot@^1.0.5:
     get-intrinsic "^1.2.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 ip-regex@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR resolves incompatibility warning messages for the npm package [@babel/compat-data](https://www.npmjs.com/package/@babel/compat-data).

## Changes

The PR removes `"@babel/compat-data": "7.9.0"` from the `resolutions` section of [package.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/package.json) and from the  `packageRules` section of [renovate.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/renovate.json).

## Resolution

It resolves a yarn warning

```text
[2/5] Resolving packages...
warning Resolution field "@babel/comdocupat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.5"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.1"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.5"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.17.7"
```

## Background

The binding of `"@babel/compat-data": "7.9.0"` was introduced in https://github.com/cypress-io/cypress-realworld-app/pull/421 in June 2020 through https://github.com/cypress-io/cypress-realworld-app/pull/421/commits/2010c66ce94a115adc32d17f5ba35b4c7d0d9fd8 with the comment "resolve babel/compat-data to v7.9.0 to fix failed to compile error". At the time, it downgraded `"@babel/compat-data": "^7.10.1"` to `"@babel/compat-data": "7.9.0"`.

[babel v7.9.0](https://github.com/babel/babel/blob/main/CHANGELOG.md#v790-2020-03-20) was released on March 20, 2020. The problematic version [babel v7.10.1](https://github.com/babel/babel/blob/main/CHANGELOG.md#v7101-2020-05-27) was released on May 27, 2020.

In the meantime, the latest version is ~~[babel v7.21.4](https://github.com/babel/babel/blob/main/CHANGELOG.md#v7214-2023-03-31) released on March 31, 2023~~ [babel v7.21.8](https://github.com/babel/babel/releases/tag/v7.21.8) released on May 2, 2023.

## Verification

With Node.js `16.16.0` and yarn `1.22.19` on
- ubuntu 22.04
- Windows 11

```bash
nvm use 16.16.0
npm install yarn@latest -g
yarn install
```

repeat

```bash
yarn install
```

and expect output similar to the following, with no warnings:

```text
yarn install v1.22.19
[1/5] Validating package.json...
[2/5] Resolving packages...
success Already up-to-date.
$ husky install
husky - Git hooks installed
Done in 0.73s.
```

The warnings which should **not** appear are:

```text
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.5"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.1"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.20.5"
warning Resolution field "@babel/compat-data@7.9.0" is incompatible with requested version "@babel/compat-data@^7.17.7"
success Already up-to-date.

```

Execute

```bash
yarn dev
```

wait for message "You can now view cypress-realworld-app in the browser.", then, in a separate terminal, execute:

```bash
yarn cypress:run
yarn cypress:run:component
```

Confirm Cypress outputs "All specs passed!".
