### PR TITLE
chore: update set-output to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/merge-develop-into-flake-demo.yml
+++ b/.github/workflows/merge-develop-into-flake-demo.yml
@@ -19,7 +19,7 @@ jobs:
         run: git checkout flake-demo
       - name: Check for merge conflict
         id: check-conflict
-        run: echo "::set-output name=merge_conflict::$(git merge-tree $(git merge-base HEAD develop) develop HEAD | egrep '<<<<<<<')"
+        run: echo "name=merge_conflict::$(git merge-tree $(git merge-base HEAD develop) develop HEAD | egrep '<<<<<<<')" >> $GITHUB_OUTPUT
       - name: Merge develop into flake-demo
         run: git merge develop
         if: ${{ !steps.check-conflict.outputs.merge_conflict }}
@@ -32,8 +32,8 @@ jobs:
       - name: Determine name of new branch
         id: gen-names
         run: |
-          echo "::set-output name=sha::$(git rev-parse --short HEAD)"
-          echo "::set-output name=branch_name::$(git rev-parse --short HEAD)-develop-into-flake-demo"
+          echo "name=sha::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "name=branch_name::$(git rev-parse --short HEAD)-develop-into-flake-demo" >> $GITHUB_OUTPUT
         if: ${{ steps.check-conflict.outputs.merge_conflict }}
       - name: Create a copy of develop on a new branch
         run: git checkout -b ${{ steps.gen-names.outputs.branch_name }} develop


### PR DESCRIPTION
Closes #1340 

Update `set-output` to `GITHUB_OUTPUT` in the `merge-develop-into-flake-demo` workflow since it has been [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).