### PR TITLE
chore: sync database copy with seed contents

### DIFF
--- a/data/database.json
+++ b/data/database.json
@@ -253,16 +253,6 @@
       "isDeleted": false,
       "createdAt": "2019-09-30T14:20:07.043Z",
       "modifiedAt": "2020-05-21T22:40:28.910Z"
-    },
-    {
-      "id": "BnFx1aBAM",
-      "uuid": "492f8922-8699-4738-96d9-fc717445be29",
-      "bankName": "The Best Bank",
-      "accountNumber": "123456789",
-      "routingNumber": "987654321",
-      "isDeleted": false,
-      "createdAt": "2022-11-30T19:27:10.571Z",
-      "modifiedAt": "2022-11-30T19:27:10.571Z"
     }
   ],
   "transactions": [


### PR DESCRIPTION
This PR syncs [data/database.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/data/database.json) from the reference copy in [data/database-seed.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/data/database-seed.json).

This resolves the issue that running `yarn dev` changes `data/database.json` and since this database file is committed to `git` it causes a `git` difference to be reported. It is not normally expected that testing would change the contents of any committed files. [README > Run the app](https://github.com/cypress-io/cypress-realworld-app#run-the-app) specifies `yarn dev` as the correct command to run the app in preparation for testing. It uses `yarn predev` to copy the database seed into the working database.

## Verification

Check `git status` before and after executing `yarn dev` and confirm that there is no change.

Test using `yarn cypress:run` and `yarn cypress:run:component`