### PR TITLE
chore(deps): node version requirement update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/cypress-io/cypress-realworld-app/issues"
   },
   "engines": {
-    "node": ">=12.22.0"
+    "node": "^16.16.0"
   },
   "dependencies": {
     "@auth0/auth0-react": "1.9.0",


### PR DESCRIPTION
- Cypress dropped support for Node.js 12, 15 and 17 with 12.0.0 release
[source](https://docs.cypress.io/guides/references/changelog#:~:text=Installing%20Cypress%20on%20your%20system,browser%20context%20through%20test%20isolation.) 