### PR TITLE
ci: tie GH windows jobs in main.yml to Node.js 16.16.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           # which has some compatibility issues with openSSL inside this windows job.
           # Node 18 updated with OpenSSL provider which causes this compatibility issue
           # downgrading node to v16 to use the openssl-legacy-provider by default to prevent this issue
-          node-version: '16'
+          node-version: '16.16.0'
 
       - name: Cypress install
         uses: cypress-io/github-action@v5
@@ -275,6 +275,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16.16.0'
 
       - name: Download the build folders
         uses: actions/download-artifact@v3


### PR DESCRIPTION
This PR corrects the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml) with name "Cypress Tests" to set the version of Node.js to `16.16.0` in the Windows jobs:

- `install-windows` (previously `16`) set up by PR https://github.com/cypress-io/cypress-realworld-app/pull/1317
- `ui-windows-tests` (previously not specified)

Node.js `16.16.0` corresponds to the value defined in [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version).

## Issue

Since the merge of PR https://github.com/cypress-io/cypress-realworld-app/pull/1352, Yarn checks that the Node.js version satisfies `^16.16.0`. Windows GitHub-hosted runners however provide a default version of Node.js `18.16.0`, which fails the Yarn Node.js engines check in the `ui-windows-tests` job of [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml). See for instance job [9503977456](https://github.com/cypress-io/cypress-realworld-app/actions/runs/5258808961/jobs/9503977456).

Although the Cypress JavaScript action `cypress-io/github-action@v5` runs in a `node16` context, commands it spawns through the `start` parameter run under the Node.js version of the context from which `cypress-io/github-action@v5` is called, in this case Node.js `18.16.0`. This applies to the failing `start: yarn start:ci` in the `ui-windows-tests` job.
