### PR TITLE
docs: add M2 mac special install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ TypeScript will be added as a local dependency to the project, so no need to ins
 yarn
 ```
 
-#### Mac M1 and M2 chip users will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
+#### Mac users with M-series chips will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
 
 ```shell
 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ TypeScript will be added as a local dependency to the project, so no need to ins
 yarn
 ```
 
-#### Mac M1 chip users will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
+#### Mac M1, M2 chip users will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
 
 ```shell
 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ TypeScript will be added as a local dependency to the project, so no need to ins
 yarn
 ```
 
-#### Mac M1, M2 chip users will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
+#### Mac M1 and M2 chip users will need to prepend `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true`.
 
 ```shell
 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true yarn install


### PR DESCRIPTION
https://github.com/cypress-io/cypress-realworld-app/issues/1207 This documentation update is related to this issue that is already closed. 

I have tested the solution in M2 series and it works properly.