### PR TITLE
chore(deps): add devDependency @babel/plugin-proposal-private-property-in-object

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yup": "0.32.11"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "7.21.11",
     "@cypress/code-coverage": "^3.10.0-dev.1",
     "@cypress/instrument-cra": "1.4.0",
     "@cypress/webpack-dev-server": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,6 +2517,16 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
+"@babel/plugin-proposal-private-property-in-object@7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
 "@babel/plugin-proposal-private-property-in-object@^7.21.0":
   version "7.21.10"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.10.tgz#861ab9c7d152291c47d27838867f27c560f562c4"


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress-realworld-app/issues/1363.

This PR mitigates the following warning:

>One of your dependencies, babel-preset-react-app, is importing the
>"@babel/plugin-proposal-private-property-in-object" package without
>declaring it in its dependencies. This is currently working because
>"@babel/plugin-proposal-private-property-in-object" is already in your
>node_modules folder for unrelated reasons, but it may break at any time.
>
>babel-preset-react-app is part of the create-react-app project, which
>is not maintianed anymore. It is thus unlikely that this bug will ever
>be fixed. If you are starting a new project, you may consider using
>maintained alternatives such as Vite (https://vitejs.dev/) instead.
>
>Add "@babel/plugin-proposal-private-property-in-object" to your
>devDependencies to work around this error. This will make this message
>go away.

## Verification

```bash
npm install yarn@latest -g
rm -rf node_modules
yarn
yarn dev
```

and confirm that the warning no longer appears.
