### PR TITLE
chore: update circleci orb to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  cypress: cypress-io/cypress@3.1.3
+  cypress: cypress-io/cypress@3.1.4
   codecov: codecov/codecov@1.2.3 #
   win: circleci/windows@5.0.0
 


### PR DESCRIPTION
chore: updating the circleci orb to latest to address chrome driver download issues in build