### PR TITLE
fix(deps): remove resolutions for @types/express

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,10 +133,6 @@
     "vite-plugin-istanbul": "^4.1.0",
     "vitest": "^0.33.0"
   },
-  "resolutions": {
-    "@types/express": "4.17.2",
-    "@types/express-serve-static-core": "4.17.2"
-  },
   "scripts": {
     "dev": "cross-env NODE_ENV=development concurrently yarn:start:react yarn:start:api:watch",
     "dev:coverage": "cross-env NODE_ENV=development CYPRESS_COVERAGE=true concurrently yarn:start:react yarn:start:api:watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4831,6 +4831,16 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
+"@types/express-serve-static-core@^4.17.33":
+  version "4.17.36"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
+  integrity sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
 "@types/express-session@1.17.4":
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/@types/express-session/-/express-session-1.17.4.tgz#97a30a35e853a61bdd26e727453b8ed314d6166b"
@@ -4845,13 +4855,23 @@
   dependencies:
     express-unless "*"
 
-"@types/express@*", "@types/express@4.17.2", "@types/express@^4.17.14":
+"@types/express@*", "@types/express@4.17.2":
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.2.tgz#a0fb7a23d8855bac31bc01d5a58cadd9b2173e6c"
   integrity sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
+
+"@types/express@^4.17.14":
+  version "4.17.17"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
+  integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
     "@types/serve-static" "*"
 
 "@types/faker@5.5.9":
@@ -4980,6 +5000,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
+"@types/mime@^1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
+  integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
 "@types/minimatch@*":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
@@ -5028,6 +5053,11 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/qs@*":
+  version "6.9.8"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.8.tgz#f2a7de3c107b89b441e071d5472e6b726b4adf45"
+  integrity sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==
 
 "@types/range-parser@*":
   version "1.2.4"
@@ -5115,6 +5145,14 @@
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.0.tgz#591c1ce3a702c45ee15f47a42ade72c2fd78978a"
   integrity sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==
+
+"@types/send@*":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.1.tgz#ed4932b8a2a805f1fe362a70f4e62d0ac994e301"
+  integrity sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.15.2"


### PR DESCRIPTION
## Issue

Executing:

```bash
yarn install
```

causes the following message to be output:

> warning Resolution field "@types/express@4.17.2" is incompatible with requested version "@types/express@^4.17.14"

[@okta/jwt-verifier](https://www.npmjs.com/package/@okta/jwt-verifier) was updated to [@okta/jwt-verifier@^3.0.1](https://github.com/okta/okta-jwt-verifier-js/releases/tag/okta-jwt-verifier-js-3.0.1) in the update to vite (PR #1396) and its dependencies call for `@types/express@^4.17.14` causing the above warning.

https://github.com/cypress-io/cypress-realworld-app/blob/e66f559f34a2dae163b366113363683f958f22c8/package.json#L136-L139

- was added by PR #413 to resolve issue #412 under Node.js `12.18`.

The repo has been migrated to Node.js `18` - see: https://github.com/cypress-io/cypress-realworld-app/blob/e66f559f34a2dae163b366113363683f958f22c8/.node-version#L1 and no longer supports or needs Node.js `12`.

The following error message no longer appears when Node.js `18` is used and so the workaround is no longer necessary and can be removed.

> Error: Cannot find module '@babel/compat-data/corejs3-shipped-proposals'

## Change

Remove the following from [package.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/package.json):

```json
  "resolutions": {
    "@types/express": "4.17.2",
    "@types/express-serve-static-core": "4.17.2"
  },
```

## Local E2E verification

With Node.js `18.16.1`, execute:

```bash
git clean -x -d -f
yarn install
yarn install
```

There should be no error concerning `@types/express`, neither for the first, nor for the second `yarn install`.

Then execute:

```bash
yarn dev
```

and in a separate terminal window execute

```bash
yarn cypress run --e2e
```

ensuring that all tests pass.
