### PR TITLE
chore(deps): update to cypress-io/github-action@v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cypress install
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           runTests: false
       # report machine parameters
@@ -45,7 +45,7 @@ jobs:
           node-version: "18.16.0"
 
       - name: Cypress install
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           runTests: false
       # report machine parameters
@@ -99,7 +99,7 @@ jobs:
         run: ls /__e
 
       - name: "UI Tests - Chrome"
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -145,7 +145,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Chrome - Mobile"
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -191,7 +191,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox"
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"
@@ -236,7 +236,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Firefox - Mobile"
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           config: "viewportWidth=375,viewportHeight=667"
           start: yarn start:ci
@@ -282,7 +282,7 @@ jobs:
           path: build
 
       - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           start: yarn start:ci
           wait-on: "http://localhost:3000"


### PR DESCRIPTION
This PR migrates the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml)

- from `cypress-io/github-action@v5` running under `node16`
- to `cypress-io/github-action@v6` running under `node20`

Node.js `16` enters [end-of-life](https://github.com/nodejs/release#release-schedule) on Sep 11, 2023.