### PR TITLE
fix: cypress info in main workflow / ui-chrome-tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,9 +89,6 @@ jobs:
           name: build
           path: build
 
-      - name: Cypress info
-        run: npx cypress info
-
       - name: Node info
         run: node -v
 
@@ -101,6 +98,7 @@ jobs:
       - name: "UI Tests - Chrome"
         uses: cypress-io/github-action@v5
         with:
+          build: yarn cypress info
           start: yarn start:ci
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120


### PR DESCRIPTION
## Issue

In the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml), job `ui-chrome-tests`

```yaml
      - name: Cypress info
        run: npx cypress info
```

is called before Cypress is installed through `cypress-io/github-action` so the latest version of Cypress is downloaded and run. The logs show:

```text
Run npx cypress info
  npx cypress info
  shell: sh -e {0}
npm WARN exec The following package was not found and will be installed: cypress@13.1.0
```

The latest version of Cypress is not necessarily the one defined in [yarn.lock](https://github.com/cypress-io/cypress-realworld-app/blob/develop/yarn.lock). At the time of writing, in fact `cypress@13.0.0` is defined, and should be used, not `cypress@13.1.0`

https://github.com/cypress-io/cypress-realworld-app/blob/c126cd62f1215d4a1872d4ca46567b0b0697721e/yarn.lock#L7087-L7088

## Resolution

- Follow the advice in [cypress-io/github-action > README > Print Cypress Info](https://github.com/cypress-io/github-action#print-cypress-info) and (mis-)use the unused `build` parameter to call `cypress info`.
- Since this is a Yarn project, use `yarn cypress info`, not `npx cypress info` for this purpose.
