### PR TITLE
feat: set yarn classic for corepack enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@
 
 # dependencies
 /node_modules
-/.pnp
-.pnp.js
 
 # testing
 /coverage
@@ -43,3 +41,14 @@ amplifyconfiguration.json
 amplify-build-config.json
 amplify-gradle-config.json
 amplifytools.xcconfig
+
+# Yarn
+# See https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
+# without zero installs
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs

--- a/README.md
+++ b/README.md
@@ -66,21 +66,17 @@ The app is bundled with [example data](./data/database.json) (`data/database.jso
 
 This project requires [Node.js](https://nodejs.org/en/) to be installed on your machine. Refer to the [.node-version](./.node-version) file for the exact version.
 
-[Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute the following to install the correct version of `yarn`.
+[Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute the following to install the npm module [yarn](https://www.npmjs.com/package/yarn) (Classic - version 1) globally.
 
-```bash
-npm install yarn -g
+```shell
+npm install yarn@latest -g
 ```
 
-The following command allows you to check that you have Yarn Classic (version 1) installed and active:
+If you have Node.js' experimental [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) feature enabled, then you should skip the step `npm install yarn@latest -g` to install Yarn Classic globally. The RWA project is locally configured for `Corepack` to use Yarn Classic (version 1).
 
-```bash
-yarn -v
-```
+#### Yarn Modern
 
 **This project is not compatible with [Yarn Modern](https://yarnpkg.com/) (version 2 and later).**
-
-TypeScript will be added as a local dependency to the project, so no need to install it.
 
 ### Installation
 

--- a/package.json
+++ b/package.json
@@ -240,5 +240,6 @@
       "html",
       "json"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-realworld-app/issues/1404

## Issue

If a user has Node.js' experimental [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) enabled, then invoking `yarn` may cause [Yarn Modern](https://yarnpkg.com/) (version 2 and later) instead of [Yarn Classic](https://classic.yarnpkg.com/) (version 1) to be used. The Cypress Real-world app is however not compatible with [Yarn Modern](https://yarnpkg.com/) and calling `yarn dev`, after installing dependencies with `yarn`, may then cause the app to crash.

Note that [Yarn Modern > Starting with Yarn > Installation](https://yarnpkg.com/getting-started/install) describes the preferred way to manage Yarn as being through [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html). Users may have other projects on their client system, besides RWA, which use Yarn Modern, and so the scenario where Corepack is enabled should be catered for by RWA.

## Changes

`"packageManager": "yarn@1.22.19"` is added to [package.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/package.json) so that if `corepack` is enabled it will use Yarn Classic and not Yarn Modern.

The instructions for users who have not executed `corepack enable` remain unchanged.

The advice that the project is not compatible with Yarn Modern also remains unchanged.

### Detailed changes

1. [README.md](https://github.com/cypress-io/cypress-realworld-app/blob/develop/README.md) is updated with instructions that work for both traditional Yarn Classic users and those who have executed `corepack enable`.

2. Yarn is set to Classic

    The following is invoked

    ```bash
    yarn set version classic
    ```

    to tie the project to Yarn Classic methods for installation, even if Yarn Modern has been set as the global default version through [corepack](https://nodejs.org/dist/latest/docs/api/corepack.html).

3. The following is merged into [.gitignore](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.gitignore) to make sure only the required Yarn files are considered for `git` commit to the repo:

    ```text
    .pnp.*
    .yarn/*
    !.yarn/patches
    !.yarn/plugins
    !.yarn/releases
    !.yarn/sdks
    !.yarn/versions
    ```
    See [Yarn Modern > Which files should be gitignored?](https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored).

## Verification

Using Node.js `18.16.1` according to [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version).

### Yarn Classic

Install Yarn Classic globally and run `yarn install`:

```bash
corepack disable
npm install yarn@latest -g
git clean -x -d -f
yarn install
git status
```

Confirm that Yarn `v1.22.19` is used to install, that there are no errors and no files identified by git for committing.

### Yarn Modern

Install Yarn Modern globally using corepack and run `yarn install`:

```bash
npm uninstall yarn -g
corepack enable
corepack prepare yarn@stable --activate
git clean -x -d -f
yarn install
git status
```

Confirm that Yarn `v1.22.19` is used to install, that there are no errors and no files identified by git for committing.
