### PR TITLE
chore: Remove windows runs from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ commands:
           paths:
             # for linux builds
             - .cache/Cypress
+            - project
           root: ~/
   attach_ws:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   cypress: cypress-io/cypress@3.2.0
   codecov: codecov/codecov@1.2.3 #
-  win: circleci/windows@5.0.0
 
 executors:
   with-chrome-and-firefox:
@@ -29,9 +28,6 @@ commands:
           paths:
             # for linux builds
             - .cache/Cypress
-            # for windows builds
-            - AppData/Local/Cypress/Cache
-            - project
           root: ~/
   attach_ws:
     steps:
@@ -42,20 +38,6 @@ commands:
       - run:
           name: Install curl
           command: apt-get update && apt-get install -y curl
-  # Setup Windows
-  # 1. Add nvm and install node 18.16.0
-  # 2. Install yarn
-  setup_node_and_yarn_windows:
-    steps:
-      - run:
-          name: Install node 18
-          command: nvm install 18.16.0
-      - run:
-          name: Use node 18
-          command: nvm use 18.16.0
-      - run:
-          name: Install yarn
-          command: npm i --location=global yarn
   # Setup
   #  1. Install Cypress
   #  2. Validate types
@@ -151,19 +133,6 @@ jobs:
     executor: with-chrome-and-firefox
     steps:
       - setup_project_and_cypress
-  setup_project_and_cypress_windows:
-    executor:
-      # executor comes from the "windows" orb
-      name: win/default
-      shell: bash.exe
-      size: large
-    steps:
-      - setup_node_and_yarn_windows
-      - run:
-          name: Disabling Windows Defender
-          shell: powershell.exe
-          command: Set-MpPreference -DisableRealtimeMonitoring $true
-      - setup_project_and_cypress
   cypress_tests_linux:
     executor: with-chrome-and-firefox
     parallelism: 5
@@ -197,38 +166,6 @@ jobs:
           isMobile: <<parameters.isMobile>>
           isComponent: <<parameters.isComponent>>
           recordPercy: <<parameters.recordPercy>>
-  cypress_tests_windows:
-    executor:
-      # executor comes from the "windows" orb
-      name: win/default
-      shell: bash.exe
-    parallelism: 5
-    parameters:
-      browser:
-        type: string
-        default: chrome
-      specPattern:
-        type: string
-        default: ""
-      ciBuildId:
-        type: string
-      group:
-        type: string
-      isMobile:
-        type: boolean
-        default: false
-      isComponent:
-        type: boolean
-        default: false
-    steps:
-      - setup_node_and_yarn_windows
-      - cypress_tests:
-          browser: <<parameters.browser>>
-          specPattern: <<parameters.specPattern>>
-          ciBuildId: <<parameters.ciBuildId>>
-          group: <<parameters.group>>
-          isMobile: <<parameters.isMobile>>
-          isComponent: <<parameters.isComponent>>
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Workflows ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #
 linux-workflow: &linux-workflow
@@ -291,22 +228,6 @@ linux-workflow: &linux-workflow
         requires:
           - Setup Linux
 
-windows-workflow: &windows-workflow
-  jobs:
-    - setup_project_and_cypress_windows:
-        name: "Setup Windows"
-    # Run E2E tests in Windows in Electron
-    - cypress_tests_windows:
-        name: "UI Tests - Electron - Windows"
-        browser: electron
-        specPattern: "cypress/tests/ui/*"
-        ciBuildId: ${CIRCLE_SHA1:0:8}
-        group: "UI - Electron - Windows"
-        requires:
-          - Setup Windows
-
 workflows:
   linux:
     <<: *linux-workflow
-  windows:
-    <<: *windows-workflow

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,34 +35,6 @@ jobs:
           if-no-files-found: error
           path: build
 
-  install-windows:
-    runs-on: windows-2022
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.16.0"
-
-      - name: Cypress install
-        uses: cypress-io/github-action@v6
-        with:
-          runTests: false
-      # report machine parameters
-      - run: yarn cypress info
-      - run: node -p 'os.cpus()'
-      - run: yarn types
-      - run: yarn lint
-      - run: yarn test:unit:ci
-      - run: yarn build:ci
-
-      - name: Save build folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: build
-          if-no-files-found: error
-          path: build
-
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -244,50 +216,6 @@ jobs:
           record: true
           parallel: true
           group: "UI - Firefox - Mobile"
-          spec: cypress/tests/ui/*
-          config-file: cypress.config.ts
-        env:
-          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  ui-windows-tests:
-    timeout-minutes: 40
-    runs-on: windows-2022
-    needs: install-windows
-    strategy:
-      # when one test fails, DO NOT cancel the other
-      # containers, because this will kill Cypress processes
-      # leaving Cypress Cloud hanging ...
-      # https://github.com/cypress-io/github-action/issues/48
-      fail-fast: false
-      matrix:
-        # run copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "18.16.0"
-
-      - name: Download the build folders
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: build
-
-      - name: "UI Tests - Electron - Windows"
-        uses: cypress-io/github-action@v6
-        with:
-          start: yarn start:ci
-          wait-on: "http://localhost:3000"
-          wait-on-timeout: 120
-          record: true
-          parallel: true
-          group: "UI - Electron - Windows"
           spec: cypress/tests/ui/*
           config-file: cypress.config.ts
         env:


### PR DESCRIPTION
The windows runs for this project run significantly slower than Linux - Linux = 5min, Windows = 18min. Because of this, we have to set the project settings to an incredibly high run completion delay (I believe it was at 12 mins when I tried to lower it). After I tried to reduce it, we often run into [these errors](https://app.circleci.com/pipelines/github/cypress-io/cypress-realworld-app/5666/workflows/7d9bc669-bb85-4c52-adf2-94fb7345dd2d/jobs/36181) about the group no longer accepting new runs.

The delay of results waiting for windows runs makes this cumbersome as an example project to show to users/customers. Nobody wants to wait several minutes after a run to get the results of the Linux machine, especially with new Intelligence features coming  for users to preview.

I don't see the value in running in Windows for this project. I suggest removing Windows runs.
- This project is not testing anything that is exclusive to Windows like the kitchensink project does. 
- This will reduce the maintenance burden 
-  It will improve the experience of viewing this projects run results in the Cloud for our users. 
- This should slightly reduce some of our CI costs.