### PR TITLE
fix: main workflow syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
       - name: "UI Tests - Chrome - Mobile"
         uses: cypress-io/github-action@v6
         with:
-          config: "'{"e2e":{"viewportWidth":375,"viewportHeight":667}}"
+          config: '{"e2e":{"viewportWidth":375,"viewportHeight":667}}'
           start: yarn start:ci
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120
@@ -208,7 +208,7 @@ jobs:
       - name: "UI Tests - Firefox - Mobile"
         uses: cypress-io/github-action@v6
         with:
-          config: "'{"e2e":{"viewportWidth":375,"viewportHeight":667}}"
+          config: '{"e2e":{"viewportWidth":375,"viewportHeight":667}}'
           start: yarn start:ci
           wait-on: "http://localhost:3000"
           wait-on-timeout: 120


### PR DESCRIPTION
## Issue

[Workflow logs for main.yml](https://github.com/cypress-io/cypress-realworld-app/actions/workflows/main.yml) show the error
> Invalid workflow file: .github/workflows/main.yml#L119
>You have an error in your yaml syntax on line 119

and the workflow fails to run.

In the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml), the jobs:

- `ui-chrome-mobile-tests`
- `ui-firefox-mobile-tests`

contain syntax errors.

- These were introduced through https://github.com/cypress-io/cypress-realworld-app/pull/1429.

## Resolution

Correct the quoting syntax in [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml)

## Verification

Check that the workflow [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml) can be run successfully.