### PR TITLE
fix(api): ensure balance is captured as number of cents when user account created

### DIFF
--- a/backend/database.ts
+++ b/backend/database.ts
@@ -186,7 +186,7 @@ export const createUser = (userDetails: Partial<User>): User => {
     password,
     email: userDetails.email!,
     phoneNumber: userDetails.phoneNumber!,
-    balance: userDetails.balance! || 0,
+    balance: Number(userDetails.balance!) || 0,
     avatar: userDetails.avatar!,
     defaultPrivacyLevel: userDetails.defaultPrivacyLevel!,
     createdAt: new Date(),

--- a/cypress/tests/api/api-users.spec.ts
+++ b/cypress/tests/api/api-users.spec.ts
@@ -135,6 +135,25 @@ describe("Users API", function () {
       });
     });
 
+    it("creates a new user with an account balance in cents", function () {
+      const firstName = faker.name.firstName();
+
+      cy.request("POST", `${apiUsers}`, {
+        firstName,
+        lastName: faker.name.lastName(),
+        username: faker.internet.userName(),
+        password: faker.internet.password(),
+        email: faker.internet.email(),
+        phoneNumber: faker.phone.phoneNumber(),
+        avatar: faker.internet.avatar(),
+        balance: 100_00,
+      }).then((response) => {
+        expect(response.status).to.eq(201);
+        expect(response.body.user).to.contain({ firstName });
+        expect(response.body.user.balance).to.equal(100_00);
+      });
+    });
+
     it("error when invalid field sent", function () {
       cy.request({
         method: "POST",


### PR DESCRIPTION
Hi Team!

I noticed that when a user account is created via a POST request with `balance` specified in the payload correctly as `number`, [`isUserValidator`](https://github.com/cypress-io/cypress-realworld-app/blob/563baf81aeae5c3e150c15a5d518888674bbbd93/backend/validators.ts#L46) converts this value to `string`.
This results in the [`createUser`](https://github.com/cypress-io/cypress-realworld-app/blob/563baf81aeae5c3e150c15a5d518888674bbbd93/backend/user-routes.ts#L41-L48) saving incorrect data type to `database.json`, which then prevents the [`NavDrawer`](https://github.com/cypress-io/cypress-realworld-app/blob/563baf81aeae5c3e150c15a5d518888674bbbd93/src/components/NavDrawer.tsx#L249) from formatting the value, and causes the entire UI to crash.

This patch ensures that whenever a user account is created programmatically, the `balance` is correctly stored as `number`.