### PR TITLE
docs: add instructions to clone repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ If you have Node.js' experimental [Corepack](https://nodejs.org/dist/latest/docs
 
 ### Installation
 
+To clone the repo to your local system and install dependencies, execute the following commands:
+
 ```shell
+git clone https://github.com/cypress-io/cypress-realworld-app
+cd cypress-realworld-app
 yarn
 ```
 


### PR DESCRIPTION
## Issue

The [README](https://github.com/cypress-io/cypress-realworld-app/blob/develop/README.md) document contains no instructions to clone the repo.

## Change

Add instructions

```shell
git clone https://github.com/cypress-io/cypress-realworld-app
```
