### PR TITLE
chore(deps): update eslint-plugin-cypress to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "8.10.0",
     "eslint-config-react-app": "^7.0.1",
-    "eslint-plugin-cypress": "2.15.2",
+    "eslint-plugin-cypress": "3.5.0",
     "eslint-plugin-prettier": "^5.0.0",
     "express": "4.19.2",
     "express-jwt": "6.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6380,10 +6380,10 @@ eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-cypress@2.15.2:
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.15.2.tgz#f22e12fad4c434edad7b298ef92bac8fa087ffa0"
-  integrity sha512-CtcFEQTDKyftpI22FVGpx8bkpKyYXBlNge6zSo0pl5/qJvBAnzaD76Vu2AsP16d6mTj478Ldn2mhgrWV+Xr0vQ==
+eslint-plugin-cypress@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-3.5.0.tgz#380ef5049ad80ebeca923db69e4aa96e72fcd893"
+  integrity sha512-JZQ6XnBTNI8h1B9M7wJSFzc48SYbh7VMMKaNTQOFa3BQlnmXPrVc4PKen8R+fpv6VleiPeej6VxloGb42zdRvw==
   dependencies:
     globals "^13.20.0"
 


### PR DESCRIPTION
## Issue

The repo is configured to use [eslint-plugin-cypress@2.15.2](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v2.15.2) which uses the configuration of ESLint 8 and this is deprecated in ESLint 9. Since [ESLint 8 end-of-life](https://eslint.org/version-support/) is in October 2024, preparations should take place to update.

## Change

Update to use [eslint-plugin-cypress@3.5.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v3.5.0) which is backwards compatible with ESLint 8 and forwards compatible with ESLint 9 using legacy or flat configurations. (For flat configurations a minimum version [eslint-plugin-cypress@3.3.0](https://github.com/cypress-io/eslint-plugin-cypress/releases/tag/v3.3.0) is required.)

## Verification

```shell
yarn
yarn eslint .
```

Ensure that ESLint runs correctly and reports linting errors.