### PR TITLE
fix(api): fix grammatical issues and improve consistency

### DIFF
--- a/cypress/tests/api/api-contacts.spec.ts
+++ b/cypress/tests/api/api-contacts.spec.ts
@@ -53,7 +53,7 @@ describe("Contacts API", function () {
       });
     });
 
-    it("error when invalid contactUserId", function () {
+    it("errors when invalid contactUserId", function () {
       cy.request({
         method: "POST",
         url: `${apiContacts}`,

--- a/cypress/tests/api/api-notifications.spec.ts
+++ b/cypress/tests/api/api-notifications.spec.ts
@@ -90,7 +90,7 @@ describe("Notifications API", function () {
       });
     });
 
-    it("error when invalid field sent", function () {
+    it("errors when invalid field sent", function () {
       cy.request({
         method: "PATCH",
         url: `${apiNotifications}/${ctx.notificationId}`,

--- a/cypress/tests/api/api-transactions.spec.ts
+++ b/cypress/tests/api/api-transactions.spec.ts
@@ -152,7 +152,7 @@ describe("Transactions API", function () {
       });
     });
 
-    it("errors when invalid field sent", function () {
+    it("errors when an invalid field sent", function () {
       cy.request({
         method: "PATCH",
         url: `${apiTransactions}/${ctx.transactionId}`,

--- a/cypress/tests/api/api-transactions.spec.ts
+++ b/cypress/tests/api/api-transactions.spec.ts
@@ -152,7 +152,7 @@ describe("Transactions API", function () {
       });
     });
 
-    it("error when invalid field sent", function () {
+    it("errors when invalid field sent", function () {
       cy.request({
         method: "PATCH",
         url: `${apiTransactions}/${ctx.transactionId}`,

--- a/cypress/tests/api/api-users.spec.ts
+++ b/cypress/tests/api/api-users.spec.ts
@@ -37,14 +37,14 @@ describe("Users API", function () {
   });
 
   context("GET /users/:userId", function () {
-    it("get a user", function () {
+    it("gets a user", function () {
       cy.request("GET", `${apiUsers}/${ctx.authenticatedUser!.id}`).then((response) => {
         expect(response.status).to.eq(200);
         expect(response.body.user).to.have.property("firstName");
       });
     });
 
-    it("error when invalid userId", function () {
+    it("errors when invalid userId", function () {
       cy.request({
         method: "GET",
         url: `${apiUsers}/1234`,
@@ -57,7 +57,7 @@ describe("Users API", function () {
   });
 
   context("GET /users/profile/:username", function () {
-    it("get a user profile by username", function () {
+    it("gets a user profile by username", function () {
       const { username, firstName, lastName, avatar } = ctx.authenticatedUser!;
       cy.request("GET", `${apiUsers}/profile/${username}`).then((response) => {
         expect(response.status).to.eq(200);
@@ -72,7 +72,7 @@ describe("Users API", function () {
   });
 
   context("GET /users/search", function () {
-    it("get users by email", function () {
+    it("gets users by email", function () {
       const { email, firstName } = ctx.searchUser!;
       cy.request({
         method: "GET",
@@ -86,7 +86,7 @@ describe("Users API", function () {
       });
     });
 
-    it("get users by phone number", function () {
+    it("gets users by phone number", function () {
       const { phoneNumber, firstName } = ctx.searchUser!;
 
       cy.request({
@@ -101,7 +101,7 @@ describe("Users API", function () {
       });
     });
 
-    it("get users by username", function () {
+    it("gets users by username", function () {
       const { username, firstName } = ctx.searchUser!;
 
       cy.request({
@@ -154,7 +154,7 @@ describe("Users API", function () {
       });
     });
 
-    it("error when invalid field sent", function () {
+    it("errors when an invalid field sent", function () {
       cy.request({
         method: "POST",
         url: `${apiUsers}`,
@@ -180,7 +180,7 @@ describe("Users API", function () {
       });
     });
 
-    it("error when invalid field sent", function () {
+    it("errors when an invalid field sent", function () {
       cy.request({
         method: "PATCH",
         url: `${apiUsers}/${ctx.authenticatedUser!.id}`,
@@ -196,7 +196,7 @@ describe("Users API", function () {
   });
 
   context("POST /login", function () {
-    it("login as user", function () {
+    it("logs in as a user", function () {
       cy.loginByApi(ctx.authenticatedUser!.username).then((response) => {
         expect(response.status).to.eq(200);
       });


### PR DESCRIPTION
For example, change it("error ...") to it("errors ...") to be grammatically correct and consistent with other styles like it("gets ...") or it("deletes ...") or it("creates ...") and other changes in the descriptions.