### PR TITLE
Refactor GraphQL intercept aliases using a map for better readability

### DIFF
--- a/cypress/tests/ui/bankaccounts.spec.ts
+++ b/cypress/tests/ui/bankaccounts.spec.ts
@@ -16,21 +16,21 @@ describe("Bank Accounts", function () {
     cy.intercept("GET", "/notifications").as("getNotifications");
 
     cy.intercept("POST", apiGraphQL, (req) => {
+      const operationAliases: Record<string, string> = {
+        ListBankAccount: "gqlListBankAccountQuery",
+        CreateBankAccount: "gqlCreateBankAccountMutation",
+        DeleteBankAccount: "gqlDeleteBankAccountMutation",
+      };
+    
       const { body } = req;
-
-      if (body.hasOwnProperty("operationName") && body.operationName === "ListBankAccount") {
-        req.alias = "gqlListBankAccountQuery";
-      }
-
-      if (body.hasOwnProperty("operationName") && body.operationName === "CreateBankAccount") {
-        req.alias = "gqlCreateBankAccountMutation";
-      }
-
-      if (body.hasOwnProperty("operationName") && body.operationName === "DeleteBankAccount") {
-        req.alias = "gqlDeleteBankAccountMutation";
+    
+      const operationName = body?.operationName;
+      
+      if (body.hasOwnProperty("operationName") && operationName && operationAliases[operationName]) {
+        req.alias = operationAliases[operationName];
       }
     });
-
+    
     cy.database("find", "users").then((user: User) => {
       ctx.user = user;
 

--- a/cypress/tests/ui/bankaccounts.spec.ts
+++ b/cypress/tests/ui/bankaccounts.spec.ts
@@ -16,21 +16,20 @@ describe("Bank Accounts", function () {
     cy.intercept("GET", "/notifications").as("getNotifications");
 
     cy.intercept("POST", apiGraphQL, (req) => {
-      const operationAliases: Record<string, string> = {
-        ListBankAccount: "gqlListBankAccountQuery",
-        CreateBankAccount: "gqlCreateBankAccountMutation",
-        DeleteBankAccount: "gqlDeleteBankAccountMutation",
-      };
-    
       const { body } = req;
-    
-      const operationName = body?.operationName;
-      
-      if (body.hasOwnProperty("operationName") && operationName && operationAliases[operationName]) {
-        req.alias = operationAliases[operationName];
+
+      if (body.hasOwnProperty("operationName") && body.operationName === "ListBankAccount") {
+        req.alias = "gqlListBankAccountQuery";
+      }
+
+      if (body.hasOwnProperty("operationName") && body.operationName === "CreateBankAccount") {
+        req.alias = "gqlCreateBankAccountMutation";
+      }
+
+      if (body.hasOwnProperty("operationName") && body.operationName === "DeleteBankAccount") {
+        req.alias = "gqlDeleteBankAccountMutation";
       }
     });
-    
     cy.database("find", "users").then((user: User) => {
       ctx.user = user;
 


### PR DESCRIPTION
Refactored the GraphQL intercept logic in `bankaccounts.spec.ts` to use a map for operation aliases. This simplifies the code. The behavior of the tests remains the same.