### PR TITLE
cy: improve api comments & contacts assertions and readability

### DIFF
--- a/cypress/tests/api/api-comments.spec.ts
+++ b/cypress/tests/api/api-comments.spec.ts
@@ -34,19 +34,22 @@ describe("Comments API", function () {
 
   context("GET /comments/:transactionId", function () {
     it("gets a list of comments for a transaction", function () {
-      cy.request("GET", `${apiComments}/${ctx.transactionId}`).then((response) => {
+      const transactionId = ctx.transactionId!;
+      cy.request("GET", `${apiComments}/${transactionId}`).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.comments.length).to.eq(1);
+        expect(response.body.comments).to.be.an("array").that.has.length(1);
       });
     });
   });
 
   context("POST /comments/:transactionId", function () {
     it("creates a new comment for a transaction", function () {
-      cy.request("POST", `${apiComments}/${ctx.transactionId}`, {
+      const transactionId = ctx.transactionId!;
+      cy.request("POST", `${apiComments}/${transactionId}`, {
         content: "This is my comment",
       }).then((response) => {
         expect(response.status).to.eq(200);
+        expect(response.body.comment.content).to.eq("This is my comment");
       });
     });
   });

--- a/cypress/tests/api/api-comments.spec.ts
+++ b/cypress/tests/api/api-comments.spec.ts
@@ -49,7 +49,6 @@ describe("Comments API", function () {
         content: "This is my comment",
       }).then((response) => {
         expect(response.status).to.eq(200);
-        expect(response.body.comment.content).to.eq("This is my comment");
       });
     });
   });

--- a/cypress/tests/api/api-contacts.spec.ts
+++ b/cypress/tests/api/api-contacts.spec.ts
@@ -63,7 +63,7 @@ describe("Contacts API", function () {
         },
       }).then((response) => {
         expect(response.status).to.eq(422);
-        expect(response.body.errors.length).to.eq(1);
+        expect(response.body.errors).to.be.an("array").that.has.length(1);
       });
     });
   });


### PR DESCRIPTION
Improved assertions in api-comments and api-contacts spec files to make them clearer and check that the response is an array with the correct length. Test logic remains the same.