### PR TITLE
chore: remove committed Yarn 1.22.22 cjs

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -3,4 +3,3 @@
 
 
 network-timeout 500000
-yarn-path ".yarn/releases/yarn-1.22.22.cjs"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,0 @@
-yarnPath: .yarn/releases/yarn-1.22.22.cjs

--- a/package.json
+++ b/package.json
@@ -245,5 +245,5 @@
       "json"
     ]
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Issue

The repo is currently configured to use [.yarn/releases/yarn-1.22.22.cjs](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.yarn/releases/yarn-1.22.22.cjs) as Yarn 1 Classic package manager if the user has Node.js experimental [corepack](https://nodejs.org/docs/latest/api/corepack.html) enabled.

For comparison, the [cypress](https://github.com/cypress-io/cypress) repo is now configured with its [package.json](https://github.com/cypress-io/cypress/blob/develop/package.json) defining the `packageManager` key **without** however committing any Yarn package manager executable code to its repo.

The [cypress](https://github.com/cypress-io/cypress) setup is sufficient to enable Yarn 1 Classic to be used. If a user does not have the configured `packageManager` version installed locally, then `corepack` will install it and store it in the `node/corepack` cache - on Ubuntu in `~/.cache/node/corepack`. It is not necessary to commit Yarn to the repo.

Concerns were raised by @emilyrohrbough in https://github.com/cypress-io/cypress-realworld-app/pull/1408#issuecomment-1798784670 from Nov 2023, although these were not followed up with actions until now.

## Background

Alternatives:

```shell
yarn set version classic # causes .yarn/releases/yarn-classic.cjs to be installed in the repo
yarn set version 1.22.22 # causes .yarn/releases/yarn-1.22.22.cjs to be installed in the repo
corepack use yarn@1 # causes only "packageManager": "yarn@1.22.22+sha512 to be set (and runs yarn)
```

## Change

- Set up [package.json](https://github.com/cypress-io/cypress/blob/develop/package.json) with `packageManager` for `yarn@1.22.22` equivalent to the version installed by `npm install yarn@latest -g` without `corepack` enabled.
- Remove the executable [.yarn/releases/yarn-1.22.22.cjs](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.yarn/releases/yarn-1.22.22.cjs) and references to it.


## Verification

On Ubuntu `24.04.1` LTS, using Node.js `20.12.0` according to [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version).

### Corepack disabled

Install Yarn Classic globally and run `yarn`:

```shell
corepack disable
npm install yarn@latest -g
yarn -v
git clean -xfd
yarn
git status
```

Confirm that Yarn `v1.22.22` is used to install, that there are no errors and no files identified by git for committing.

### Corepack enabled

Enable `corepack` and run `yarn`:

```shell
corepack disable
rm -rf ~/.cache/node/corepack
npm uninstall yarn -g
corepack enable yarn
git clean -xfd
yarn
git status
```

Confirm that Corepack prompts to install https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz, and after confirming with "Y", that yarn is downloaded and then installs dependencies with no errors. There should also be no files identified by git for committing after yarn install has completed.
