### PR TITLE
fix(deps): drop node.js 18 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "postinstall": "husky install && patch-package"
   },
   "engines": {
-    "node": "^18.0.0 || ^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0"
   },
   "eslintConfig": {
     "env": {


### PR DESCRIPTION
## Situation

- The recommended Node.js version for this repo is Node.js `22.15.0` LTS as defined in [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version)
https://github.com/cypress-io/cypress-realworld-app/blob/9aa2f45933350e699dd80626cf93008369032d79/.node-version#L1
- Additionally https://github.com/cypress-io/cypress-realworld-app/blob/9aa2f45933350e699dd80626cf93008369032d79/package.json#L194-L196 restricts the Node.js usage
- Node.js 18 entered [end-of-life](https://github.com/nodejs/Release/blob/main/README.md#end-of-life-releases) on Apr 30, 2025.

## Change

Remove Node.js `^18.0.0` from [package.json](https://github.com/cypress-io/cypress-realworld-app/blob/develop/package.json)

## Comment

This repo is not published as an npm module, so there is no new version to publish, and no explicit breaking change to be notified.