### PR TITLE
chore(deps): update to cypress/browsers:22.15.0 Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome-and-firefox:
     docker:
-      - image: "cypress/browsers:node-22.15.0-chrome-135.0.7049.114-1-ff-137.0.2-edge-135.0.3179.85-1"
+      - image: "cypress/browsers:22.15.0"
     resource_class: large
     environment:
       CYPRESS_coverage: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1
+      image: cypress/browsers:22.15.0
       options: --user 1001
     steps:
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1
+      image: cypress/browsers:22.15.0
       options: --user 1001
     needs: install
     strategy:
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1
+      image: cypress/browsers:22.15.0
       options: --user 1001
     needs: install
     strategy:
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1
+      image: cypress/browsers:22.15.0
       options: --user 1001
     needs: install
     strategy:
@@ -183,7 +183,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1
+      image: cypress/browsers:22.15.0
       options: --user 1001
     needs: install
     strategy:


### PR DESCRIPTION
## Situation

Cypress Docker images are used in CI as follows:

- [.github/workflows/main.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.github/workflows/main.yml) uses `cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1`
- [.circleci/config.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.circleci/config.yml) uses `cypress/browsers:node-22.15.0-chrome-135.0.7049.114-1-ff-137.0.2-edge-135.0.3179.85-1`

## Assessment

1. `cypress/browsers:node-22.13.0-chrome-132.0.6834.83-1-ff-134.0.1-edge-131.0.2903.147-1` is now unsupported, according to the "latest 3 browser version" rule. For instance Chrome latest is now `136`, so the lowest supported version is Chrome `134`.
2. Long-form Docker tags cannot be updated by Renovate, whereas short-form tags can.

## Change

Harmonize Cypress Docker usage to the short-form tag version of `cypress/browsers` using `cypress/browsers:22.15.0` corresponding to the current [Node.js Active LTS](https://github.com/nodejs/release) version Node.js `22.15.0`.