### PR TITLE
ci: use wait-on in CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           steps:
             - cypress/run-tests:
                 start-command: yarn start:ci
-                cypress-command: yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>> --config '{"e2e":{"viewportWidth":375,"viewportHeight":667}}'
+                cypress-command: yarn wait-on http://localhost:3001 && yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>> --config '{"e2e":{"viewportWidth":375,"viewportHeight":667}}'
       - when:
           condition:
             and:
@@ -120,7 +120,7 @@ commands:
                 steps:
                   - cypress/run-tests:
                       start-command: yarn start:ci
-                      cypress-command: yarn percy exec -- yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>>
+                      cypress-command: yarn wait-on http://localhost:3001 && yarn percy exec -- yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>>
             - when:
                 condition:
                   and:
@@ -128,7 +128,7 @@ commands:
                 steps:
                   - cypress/run-tests:
                       start-command: yarn start:ci
-                      cypress-command: yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>>
+                      cypress-command: yarn wait-on http://localhost:3001 && yarn cypress run --ci-build-id=<<parameters.ciBuildId>> --group="<<parameters.group>>" --record --parallel --spec=<<parameters.specPattern>> --browser=<<parameters.browser>>
       - report-coverage
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Jobs ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ #

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -95,6 +95,9 @@ if (process.env.VITE_GOOGLE) {
   app.use(checkGoogleJwt);
 }
 
+app.get("/", (req, res) => {
+  res.send("Cypress Realworld App - backend");
+});
 app.use("/graphql", gqlPlaygroundRoutes);
 app.use(
   "/graphql",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
     "vite": "^4.4.2",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-istanbul": "^4.1.0",
-    "vitest": "^0.33.0"
+    "vitest": "^0.33.0",
+    "wait-on": "^8.0.3"
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development concurrently yarn:start:react yarn:start:api:watch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4885,6 +4885,15 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^1.8.2:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axobject-query@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
@@ -7164,7 +7173,7 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
   integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.15.0, follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -8492,7 +8501,7 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-joi@^17.4.0:
+joi@^17.13.3, joi@^17.4.0:
   version "17.13.3"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.13.3.tgz#0f5cc1169c999b30d344366d384b12d92558bcec"
   integrity sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==
@@ -11078,7 +11087,7 @@ rxjs@^7.1.0, rxjs@^7.8.1:
   dependencies:
     tslib "^2.1.0"
 
-rxjs@^7.5.1:
+rxjs@^7.5.1, rxjs@^7.8.2:
   version "7.8.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
@@ -12614,6 +12623,17 @@ wait-on@6.0.0:
     lodash "^4.17.21"
     minimist "^1.2.5"
     rxjs "^7.1.0"
+
+wait-on@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-8.0.3.tgz#a23c684115d68059d739ce4eb18a3f88088d2d16"
+  integrity sha512-nQFqAFzZDeRxsu7S3C7LbuxslHhk+gnJZHyethuGKAn2IVleIbTB9I3vJSQiSR+DifUqmdzfPMoMPJfLqMF2vw==
+  dependencies:
+    axios "^1.8.2"
+    joi "^17.13.3"
+    lodash "^4.17.21"
+    minimist "^1.2.8"
+    rxjs "^7.8.2"
 
 walk-up-path@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
## Situation

- Since PR #1634 the [CircleCI pipeline](https://app.circleci.com/pipelines/github/cypress-io/cypress-realworld-app?branch=develop)  using [.circleci/config.yml](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.circleci/config.yml) has become flaky. The update through https://github.com/cypress-io/cypress-realworld-app/pull/1635 now seems to make the problem into a hard error.

E2E tests are failing with:

>     CypressError: `cy.task('db:seed')` failed with the following error:
>
> connect ECONNREFUSED 127.0.0.1:3001

## Assessment

- Port `3000` is used by the frontend
- Port `3001` is used by the API backend

Updates to dependencies may have changed the timing so that the API backend may not be available fast enough for Cypress to start testing E2E tests. `ECONNREFUSED` is typical for a server that is starting up and not yet ready.

## Change

1. Install the npm package [wait-on](https://www.npmjs.com/package/wait-on)
2. Add backend response to `/`
3. Prepend `yarn wait-on http://localhost:3001` to `cypress run` for E2E tests

## Related

- probably can close issue https://github.com/cypress-io/cypress-realworld-app/issues/1592