### PR TITLE
fix(tests): remove cypress/tests/ui/transaction-feeds.spec.ts wait workaround

### DIFF
--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -186,11 +186,6 @@ describe("Transaction Feed", function () {
           .its("response.body.results")
           .should("have.length", Cypress.env("paginationPageSize"));
 
-        // Temporary fix: https://github.com/cypress-io/cypress-realworld-app/issues/338
-        if (isMobile()) {
-          cy.wait(10);
-        }
-
         cy.log("📃 Scroll to next page");
         cy.getBySel("transaction-list").children().scrollTo("bottom");
 
@@ -252,8 +247,8 @@ describe("Transaction Feed", function () {
                     start: startOfDayUTC(dateRangeStart),
                     end: dateRangeEnd,
                   }),
-                  `transaction created date (${createdAtDate.toISOString()}) 
-                  is within ${dateRangeStart.toISOString()} 
+                  `transaction created date (${createdAtDate.toISOString()})
+                  is within ${dateRangeStart.toISOString()}
                   and ${dateRangeEnd.toISOString()}`
                 ).to.equal(true);
               });


### PR DESCRIPTION
- partial resolution of issue https://github.com/cypress-io/cypress-realworld-app/issues/1547

## Situation

If the repo is manually linted with ESLint then multiple issues are reported. This includes a report from the [cypress/no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md) rule in:

https://github.com/cypress-io/cypress-realworld-app/blob/a7de4490817f6ebb4908537b438f170343ceccd6/cypress/tests/ui/transaction-feeds.spec.ts#L189-L192

referring to the closed issue https://github.com/cypress-io/cypress-realworld-app/issues/338 from May 2020.

In this issue https://github.com/cypress-io/cypress-realworld-app/issues/338#issuecomment-642860853 it says:

> No longer an issue.

## Change

Remove the arbitrary `cy.wait(10)` workaround from [cypress/tests/ui/transaction-feeds.spec.ts](https://github.com/cypress-io/cypress-realworld-app/blob/develop/cypress/tests/ui/transaction-feeds.spec.ts)

## Verification

Ubuntu `24.04.2` LTS, Node.js `22.15.0` according to [.node-version](https://github.com/cypress-io/cypress-realworld-app/blob/develop/.node-version), Yarn `1.22.22`

Execute

```shell
git clean -xfd
yarn
yarn eslint .
```

and confirm that there are no reports of [cypress/no-unnecessary-waiting](https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-unnecessary-waiting.md). (Note other linting errors remain.)

```shell
yarn dev
yarn cypress:run # in a separate terminal window after backend server reports running
```

Tests should run without errors.
