### PR TITLE
ci(deps): update to cypress/browsers:22.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   with-chrome-and-firefox:
     docker:
-      - image: "cypress/browsers:22.16.0"
+      - image: "cypress/browsers:22.20.0"
     resource_class: large
     environment:
       CYPRESS_coverage: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:22.16.0
+      image: cypress/browsers:22.20.0
       options: --user 1001
     steps:
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:22.16.0
+      image: cypress/browsers:22.20.0
       options: --user 1001
     needs: install
     strategy:
@@ -92,7 +92,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:22.16.0
+      image: cypress/browsers:22.20.0
       options: --user 1001
     needs: install
     strategy:
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:22.16.0
+      image: cypress/browsers:22.20.0
       options: --user 1001
     needs: install
     strategy:
@@ -183,7 +183,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:22.16.0
+      image: cypress/browsers:22.20.0
       options: --user 1001
     needs: install
     strategy:


### PR DESCRIPTION
## Situation

The repo is configured to use `cypress/browsers:22.16.0` in CI. This version of the Cypress Docker image, based on Node.js `22.16.0`, has a full tag `node-22.16.0-chrome-137.0.7151.119-1-ff-139.0.4-edge-137.0.3296.62-1` meaning that it uses browsers as shown. Cypress officially supports the latest 3 major versions of Chrome, Firefox, and Edge.

| Browser | Docker image version | Latest version | Supported versions | Minimum version |
| ------- | -------------------- | -------------- | ------------------ | --------------- |
| Chrome  | 137                  | 141            | 141 140 139        | 139             |
| Edge    | 137                  | 141            | 141 140 139        | 139             |
| Firefox | 139                  | ~~143~~ 144            | 144 143 142 ~~141~~        | ~~141~~ 142             |

The Docker image  `cypress/browsers:22.16.0` is therefore providing a test environment with browser versions that are no longer supported by Cypress and so it needs updating.

## Change

Update to `cypress/browsers:22.20.0` with a full tag `node-22.20.0-chrome-140.0.7339.207-1-ff-143.0.1-edge-140.0.3485.81-1` that provides for minimum supported versions of browsers.
