### PR TITLE
fix(test): explicitly added `fileParallelism: false` to ci

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
       environment: "jsdom",
       setupFiles: "./src/setup-tests.js",
       exclude: ["node_modules", "cypress", "dist"],
+      fileParallelism: false, // #1666: Run tests sequentially to avoid race conditions with shared database.json file.
     },
   };
 });


### PR DESCRIPTION
Work around for #1666, explicitly make vitest test files in serial to prevent contamination of `database.json`. Ran ci pipeline with this change ~50 times and did not see any flakiness.