### PR TITLE
chore: update node engines to accept 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "postinstall": "husky install && patch-package"
   },
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that broadens the supported Node.js version range; the main risk is CI/runtime differences when contributors run on Node 24.
> 
> **Overview**
> Updates `package.json` `engines.node` to additionally allow Node.js `^24.0.0` alongside the existing `^20` and `^22` ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3538b109582d080b0a7f865a761052c6e5a879ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->