### PR TITLE
fix: updates endpoint for DiceBear avatar API

### DIFF
--- a/data/database-seed.json
+++ b/data/database-seed.json
@@ -9,7 +9,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Santos.Runte65@gmail.com",
       "phoneNumber": "398-225-9900",
-      "avatar": "https://avatars.dicebear.com/api/human/uBmeaz5pX.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Ted",
       "defaultPrivacyLevel": "public",
       "balance": 150953,
       "createdAt": "2023-03-09T22:26:40.101Z",
@@ -24,7 +24,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Skyla.Stamm@yahoo.com",
       "phoneNumber": "410-786-2112",
-      "avatar": "https://avatars.dicebear.com/api/human/GjWovtg2hr.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Kristian",
       "defaultPrivacyLevel": "private",
       "balance": 93026,
       "createdAt": "2023-04-23T13:52:10.979Z",
@@ -39,7 +39,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Marielle_Wiza@yahoo.com",
       "phoneNumber": "887-309-1593",
-      "avatar": "https://avatars.dicebear.com/api/human/_XblMqbuoP.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Darrel",
       "defaultPrivacyLevel": "contacts",
       "balance": 158880,
       "createdAt": "2023-05-21T05:01:54.594Z",
@@ -54,7 +54,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Norma27@gmail.com",
       "phoneNumber": "467-316-5352",
-      "avatar": "https://avatars.dicebear.com/api/human/M1ty1gR8B3.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Ruthie",
       "defaultPrivacyLevel": "private",
       "balance": 117683,
       "createdAt": "2024-02-08T11:33:03.159Z",
@@ -69,7 +69,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Nigel54@hotmail.com",
       "phoneNumber": "990-583-8419",
-      "avatar": "https://avatars.dicebear.com/api/human/WHjJ4qR2R2.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Lia",
       "defaultPrivacyLevel": "public",
       "balance": 49474,
       "createdAt": "2023-12-07T04:39:38.383Z",
@@ -10986,3 +10986,4 @@
     }
   ]
 }
+

--- a/data/database.json
+++ b/data/database.json
@@ -9,7 +9,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Santos.Runte65@gmail.com",
       "phoneNumber": "398-225-9900",
-      "avatar": "https://avatars.dicebear.com/api/human/uBmeaz5pX.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Ted",
       "defaultPrivacyLevel": "public",
       "balance": 150953,
       "createdAt": "2023-03-09T22:26:40.101Z",
@@ -24,7 +24,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Skyla.Stamm@yahoo.com",
       "phoneNumber": "410-786-2112",
-      "avatar": "https://avatars.dicebear.com/api/human/GjWovtg2hr.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Kristian",
       "defaultPrivacyLevel": "private",
       "balance": 93026,
       "createdAt": "2023-04-23T13:52:10.979Z",
@@ -39,7 +39,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Marielle_Wiza@yahoo.com",
       "phoneNumber": "887-309-1593",
-      "avatar": "https://avatars.dicebear.com/api/human/_XblMqbuoP.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Darrel",
       "defaultPrivacyLevel": "contacts",
       "balance": 158880,
       "createdAt": "2023-05-21T05:01:54.594Z",
@@ -54,7 +54,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Norma27@gmail.com",
       "phoneNumber": "467-316-5352",
-      "avatar": "https://avatars.dicebear.com/api/human/M1ty1gR8B3.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Ruthie",
       "defaultPrivacyLevel": "private",
       "balance": 117683,
       "createdAt": "2024-02-08T11:33:03.159Z",
@@ -69,7 +69,7 @@
       "password": "$2a$10$nSaCsTPTtbbPTnFXBH0GZu0ExpNMud3d1IuKOC/6a9gwAHkdhppeu",
       "email": "Nigel54@hotmail.com",
       "phoneNumber": "990-583-8419",
-      "avatar": "https://avatars.dicebear.com/api/human/WHjJ4qR2R2.svg",
+      "avatar": "https://api.dicebear.com/9.x/pixel-art/svg?seed=Lia",
       "defaultPrivacyLevel": "public",
       "balance": 49474,
       "createdAt": "2023-12-07T04:39:38.383Z",
@@ -10986,3 +10986,4 @@
     }
   ]
 }
+

--- a/scripts/seedDataUtils.ts
+++ b/scripts/seedDataUtils.ts
@@ -109,7 +109,7 @@ export const getRandomTransactions = (baseCount: number, baseTransactions: Trans
   ).slice(0, baseCount);
 
 export const getUserAvatar = (identifier: string) => {
-  return `https://avatars.dicebear.com/api/human/${identifier}.svg`;
+  return `https://api.dicebear.com/9.x/pixel-art/svg?seed=${encodeURIComponent(identifier)}`;
 };
 
 export const createFakeUser = (): User => {


### PR DESCRIPTION
Hi, this is a very small PR to update the endpoints for the DiceBear API for the avatars used on the RWA

It consists of mainly 2 changes:

- Replaces outdated DiceBear API to new v9 version while keeping the previous avatar pixel-art style
- Also forces URL-encoding on "getUserAvatar()" when creating fake user data to avoid encoding problems