### PR TITLE
test: update Cypress 16 visibility — use not.exist for closed MUI Popover

### DIFF
--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -352,14 +352,7 @@ describe("Transaction Feed", function () {
           cy.getBySel("amount-range-filter-drawer").should("not.exist");
         } else {
           cy.getBySel("transaction-list-filter-amount-clear-button").click();
-          // Dismiss the amount-range MUI Popover by clicking its backdrop
-          // before opening the date-range filter. The original test relied
-          // on the next button click implicitly closing the popover and
-          // legacy Cypress detecting the Grow transition's scale(0) as
-          // hidden — Cypress 16's modern visibility algorithm doesn't
-          // analyze transforms, so explicitly close the popover and assert
-          // its content is unmounted.
-          cy.get(".MuiBackdrop-root").click({ force: true });
+          cy.get(".MuiBackdrop-root").click();
           cy.getBySel("transaction-list-filter-amount-range").should("not.exist");
           cy.getBySel("main").scrollTo("top");
           cy.getBySel("transaction-list-filter-date-range-button").click({ force: true });

--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -352,16 +352,17 @@ describe("Transaction Feed", function () {
           cy.getBySel("amount-range-filter-drawer").should("not.exist");
         } else {
           cy.getBySel("transaction-list-filter-amount-clear-button").click();
+          // Dismiss the amount-range MUI Popover by clicking its backdrop
+          // before opening the date-range filter. The original test relied
+          // on the next button click implicitly closing the popover and
+          // legacy Cypress detecting the Grow transition's scale(0) as
+          // hidden — Cypress 16's modern visibility algorithm doesn't
+          // analyze transforms, so explicitly close the popover and assert
+          // its content is unmounted.
+          cy.get(".MuiBackdrop-root").click({ force: true });
+          cy.getBySel("transaction-list-filter-amount-range").should("not.exist");
           cy.getBySel("main").scrollTo("top");
           cy.getBySel("transaction-list-filter-date-range-button").click({ force: true });
-          // The amount-range filter lives inside an MUI Popover that
-          // unmounts when closed (keepMounted defaults to false). Assert
-          // the element no longer exists rather than relying on
-          // should('not.be.visible'), which depended on the legacy
-          // algorithm detecting the Grow transition's scale(0) as hidden —
-          // the modern Cypress 16 visibility algorithm doesn't analyze
-          // transforms.
-          cy.getBySel("transaction-list-filter-amount-range").should("not.exist");
         }
 
         cy.get("@unfilteredResults").then((unfilteredResults) => {

--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -354,7 +354,14 @@ describe("Transaction Feed", function () {
           cy.getBySel("transaction-list-filter-amount-clear-button").click();
           cy.getBySel("main").scrollTo("top");
           cy.getBySel("transaction-list-filter-date-range-button").click({ force: true });
-          cy.getBySel("transaction-list-filter-amount-range").should("not.be.visible");
+          // The amount-range filter lives inside an MUI Popover that
+          // unmounts when closed (keepMounted defaults to false). Assert
+          // the element no longer exists rather than relying on
+          // should('not.be.visible'), which depended on the legacy
+          // algorithm detecting the Grow transition's scale(0) as hidden —
+          // the modern Cypress 16 visibility algorithm doesn't analyze
+          // transforms.
+          cy.getBySel("transaction-list-filter-amount-range").should("not.exist");
         }
 
         cy.get("@unfilteredResults").then((unfilteredResults) => {

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "postinstall": "husky install && patch-package"
   },
   "engines": {
-    "node": "^20.0.0 || ^22.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary

Cypress 16 changes the default visibility algorithm to use the browser's native `Element.checkVisibility()` API, which intentionally does not analyze CSS transforms. The amount-range filter lives inside an MUI `Popover` that uses the `Grow` transition (`transform: scale(0)` when closed). The legacy algorithm detected the scaled-down element as hidden; modern does not.

When the Popover closes, MUI unmounts its content (`keepMounted` defaults to `false`), so `should('not.exist')` is the semantically correct assertion and is algorithm-agnostic.

Affects three tests in `cypress/tests/ui/transaction-feeds.spec.ts`:

- `filters public transaction feed by amount range`
- `filters contacts transaction feed by amount range`
- `filters personal transaction feed by amount range`

## Test plan

- [x] Run `cypress run --spec cypress/tests/ui/transaction-feeds.spec.ts` with a Cypress 16.x build (default `visibilityStrategy: 'modern'`) and verify the three failing tests now pass.
- [x] Re-run with `visibilityStrategy: 'legacy'` set in `cypress.config.ts` — tests should still pass since `not.exist` is algorithm-agnostic.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust Cypress assertions/steps around closing an MUI popover, with no production code impact.
> 
> **Overview**
> Updates the transaction-feed Cypress amount-range filter tests to explicitly close the desktop MUI popover (clicking the backdrop) and assert the filter UI `not.exist` after clearing, instead of relying on `not.be.visible`.
> 
> This makes the tests compatible with Cypress 16’s modern visibility checks while keeping the same functional expectations (results revert to the unfiltered dataset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4829cfbdcf4115c2297f3ac0b5e4d9df0c27e822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->