### PR TITLE
fix merge-develop-into-flake-demo workflow

### DIFF
--- a/.github/workflows/merge-develop-into-flake-demo.yml
+++ b/.github/workflows/merge-develop-into-flake-demo.yml
@@ -19,7 +19,10 @@ jobs:
         run: git checkout flake-demo
       - name: Check for merge conflict
         id: check-conflict
-        run: echo "name=merge_conflict::$(git merge-tree $(git merge-base HEAD develop) develop HEAD | egrep '<<<<<<<')" >> $GITHUB_OUTPUT
+        run: |
+          if git merge-tree "$(git merge-base HEAD develop)" develop HEAD | grep -q '<<<<<<<'; then
+            echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Merge develop into flake-demo
         run: git merge develop
         if: ${{ !steps.check-conflict.outputs.merge_conflict }}
@@ -32,8 +35,8 @@ jobs:
       - name: Determine name of new branch
         id: gen-names
         run: |
-          echo "name=sha::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "name=branch_name::$(git rev-parse --short HEAD)-develop-into-flake-demo" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "branch_name=$(git rev-parse --short HEAD)-develop-into-flake-demo" >> $GITHUB_OUTPUT
         if: ${{ steps.check-conflict.outputs.merge_conflict }}
       - name: Create a copy of develop on a new branch
         run: git checkout -b ${{ steps.gen-names.outputs.branch_name }} develop

--- a/.github/workflows/merge-develop-into-flake-demo.yml
+++ b/.github/workflows/merge-develop-into-flake-demo.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - develop
 jobs:
-  merge-master-into-develop:
+  merge-develop-into-flake-demo:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Three fixes in the Check for merge conflict and Determine name of new branch steps:

Stop writing conflict markers to $GITHUB_OUTPUT — the old command embedded <<<<<<< .our into the output file, which the Actions runner tried to parse as a heredoc delimiter and threw a hard error. Now it just writes merge_conflict=true when a conflict is detected, and nothing otherwise.
Fix the sha output key — name=sha::abc1234 was setting a key called name, not sha. Changed to sha=abc1234.
Fix the branch_name output key — same problem. name=branch_name::... was overwriting the name key. Changed to branch_name=....

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow fixes with no application or security impact.
> 
> **Overview**
> Fixes the **merge develop → flake-demo** GitHub Actions workflow so conflict handling and downstream steps behave correctly.
> 
> The **Check for merge conflict** step no longer writes merge conflict marker text into `$GITHUB_OUTPUT` (which could break the Actions runner). It now sets `merge_conflict=true` only when `git merge-tree` output contains conflict markers.
> 
> The **Determine name of new branch** step now writes `sha` and `branch_name` as proper output keys instead of the incorrect `name=sha::` / `name=branch_name::` form, so the conflict PR branch name and title get the right values.
> 
> The job id is renamed from `merge-master-into-develop` to **`merge-develop-into-flake-demo`** to match what the workflow does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087a0a19572e9f8582677de99e2b4f29c8aafc83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->