### PR TITLE
fix(ci): merge-develop-into-flake-demo workflow github-script failure

### DIFF
--- a/.github/workflows/merge-develop-into-flake-demo.yml
+++ b/.github/workflows/merge-develop-into-flake-demo.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pull = await github.pulls.create({
+            const pull = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               base: 'flake-demo',
@@ -61,13 +61,13 @@ jobs:
               @${context.actor}`,
               maintainer_can_modify: true,
             })
-            await github.pulls.requestReviewers({
+            await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: pull.data.number,
               reviewers: [context.actor],
             })
-            await github.issues.addLabels({
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pull.data.number,

--- a/.github/workflows/merge-develop-into-flake-demo.yml
+++ b/.github/workflows/merge-develop-into-flake-demo.yml
@@ -19,7 +19,10 @@ jobs:
         run: git checkout flake-demo
       - name: Check for merge conflict
         id: check-conflict
-        run: echo "name=merge_conflict::$(git merge-tree $(git merge-base HEAD develop) develop HEAD | egrep '<<<<<<<')" >> $GITHUB_OUTPUT
+        run: |
+          if git merge-tree "$(git merge-base HEAD develop)" develop HEAD | grep -q '<<<<<<<'; then
+            echo "merge_conflict=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Merge develop into flake-demo
         run: git merge develop
         if: ${{ !steps.check-conflict.outputs.merge_conflict }}
@@ -32,8 +35,8 @@ jobs:
       - name: Determine name of new branch
         id: gen-names
         run: |
-          echo "name=sha::$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "name=branch_name::$(git rev-parse --short HEAD)-develop-into-flake-demo" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "branch_name=$(git rev-parse --short HEAD)-develop-into-flake-demo" >> $GITHUB_OUTPUT
         if: ${{ steps.check-conflict.outputs.merge_conflict }}
       - name: Create a copy of develop on a new branch
         run: git checkout -b ${{ steps.gen-names.outputs.branch_name }} develop


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow script change with no application or security logic impact.
> 
> **Overview**
> Fixes the **merge develop into flake-demo** workflow when a merge conflict triggers automatic PR creation. The `github-script` step now calls Octokit’s **`github.rest.*`** APIs (`pulls.create`, `pulls.requestReviewers`, `issues.addLabels`) instead of the old **`github.pulls`** / **`github.issues`** shortcuts, which aligns with current `actions/github-script` / Octokit behavior and should stop the script from failing on conflict paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a056461691a4b706793ba74ffb6987c71e3cf433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->