### PR TITLE
docs: specify yarn@1 for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ This project requires [Node.js](https://nodejs.org/en/) to be installed on your 
 [Yarn Classic](https://classic.yarnpkg.com/) is also required. Once you have [Node.js](https://nodejs.org/en/) installed, execute the following to install the npm module [yarn](https://www.npmjs.com/package/yarn) (Classic - version 1) globally.
 
 ```shell
-npm install yarn@latest -g
+npm install yarn@1 -g
 ```
 
-If you have Node.js' experimental [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) feature enabled, then you should skip the step `npm install yarn@latest -g` to install Yarn Classic globally. The RWA project is locally configured for `Corepack` to use Yarn Classic (version 1).
+If you have Node.js' experimental [Corepack](https://nodejs.org/dist/latest/docs/api/corepack.html) feature enabled,
+then you should skip the step `npm install yarn@1 -g` to install Yarn Classic globally.
+The RWA project is locally configured for `Corepack` to use Yarn Classic (version 1).
 
 #### Yarn Modern
 


### PR DESCRIPTION
- closes https://github.com/cypress-io/cypress-realworld-app/issues/1714

## Situation

The `README` document section [Prerequisites](https://github.com/cypress-io/cypress-realworld-app#prerequisites) advises to install Yarn v1 Classic with:

```shell
npm install yarn@latest -g
```

This is no longer aligned with https://classic.yarnpkg.com/lang/en/docs/install/#windows-stable which now more accurately specifies:

```shell
npm install --global yarn@1
```

using specifically Yarn v1.

Yarn v6 is currently under development and may possibly be published to the npm registry. Specifying `yarn@latest` could in future install the wrong version.

## Change

In the `README` document section [Prerequisites](https://github.com/cypress-io/cypress-realworld-app#prerequisites) replace the instructions with:

```shell
npm install yarn@1 -g
```

to install the latest Yarn v1 Classic version.

## Verification

On Ubuntu 24.04.4 LTS, Node.js 22.20.0

```shell
corepack disable yarn
npm install yarn@1 -g
git clone https://github.com/cypress-io/cypress-realworld-app
cd cypress-realworld-app
yarn
```

Confirm that dependencies are successfully installed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to setup instructions; no application or CI behavior is modified.
> 
> **Overview**
> Updates **README** prerequisites so contributors install **Yarn Classic v1** explicitly instead of `yarn@latest`.
> 
> The global install command is now `npm install yarn@1 -g`, and the Corepack note is reworded/wrapped to match that command. This avoids accidentally pulling a future non–v1 Yarn from npm when `@latest` no longer points at Classic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164f485cf23b812dd1692ad42049cc42ac5563f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->