### PR TITLE
chore: fix stale Cypress config keys in custom-port instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ yarn cypress:open
 > 🚩 **Note**
 >
 > If you have changed the default ports, then you need to update Cypress configuration file (`cypress.config.ts`) locally.
-> There are three properties that you need to update in `cypress.config.ts`: `e2e.baseUrl`, `env.apiUrl`, and `env.url`.
-> The port number in `e2e.baseUrl` corresponds to `PORT` variable in `.env` file. Similarly, the port number in `env.apiUrl` and `env.url` correspond to `VITE_BACKEND_PORT`.
+> There are three properties that you need to update in `cypress.config.ts`: `e2e.baseUrl`, `expose.apiUrl`, and `expose.codeCoverage.url`.
+> The port number in `e2e.baseUrl` corresponds to `PORT` variable in `.env` file. Similarly, the port number in `expose.apiUrl` and `expose.codeCoverage.url` correspond to `VITE_BACKEND_PORT`.
 > For example, if you have changed `PORT` to `13000` and `VITE_BACKEND_PORT` to `13001` in `.env` file, then your `cypress.config.ts` should look similar to the following snippet:
 >
 > ```js
 > {
->   env: {
+>   expose: {
 >     apiUrl: "http://localhost:13001",
 >     codeCoverage: {
 >       url: "http://localhost:13001/__coverage__"

--- a/src/utils/portUtils.ts
+++ b/src/utils/portUtils.ts
@@ -14,7 +14,7 @@ export const getBackendPort = async () => {
 
       console.log(
         chalk.red(
-          `Failed to start the backend server on port ${backendPort}. \n Starting the backend server on port ${_port}. \n Please update VITE_BACKEND_PORT in the .env file and 'apiUrl' in cypress.json to ${_port}.`
+          `Failed to start the backend server on port ${backendPort}. \n Starting the backend server on port ${_port}. \n Please update VITE_BACKEND_PORT in the .env file and 'expose.apiUrl' in cypress.config.ts to ${_port}.`
         )
       );
       return _port;


### PR DESCRIPTION
Fixes #1722.

## What

The custom-port setup instructions still referenced the old `env`-based Cypress config keys. This updates them to the current `expose`-based keys:

- **README.md** — the custom-port note now points to `e2e.baseUrl`, `expose.apiUrl`, and `expose.codeCoverage.url` (there was no `env.url`; the actual second URL is `codeCoverage.url`), and the example snippet uses an `expose:` block to match the current config shape.
- **src/utils/portUtils.ts** — the port-conflict console message now tells users to update `expose.apiUrl` in `cypress.config.ts` instead of `apiUrl` in `cypress.json`.

## Why

The `Cypress.env()` → `Cypress.expose()` migration (#1715) moved the backend URL keys into the `expose` block, and `setupNodeEvents` builds `testDataApiEndpoint` from `config.expose.apiUrl`. Following the stale docs, a developer changing `PORT` / `VITE_BACKEND_PORT` would edit `env.apiUrl` / `env.url` — keys that no longer affect the backend endpoint Cypress tasks actually use. The `cypress.json` reference is also obsolete since the config is now TypeScript.

## Validation

- `npx --yes prettier@3 --check README.md src/utils/portUtils.ts` — passes
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and log-message text only; no runtime or test behavior changes.
> 
> **Overview**
> Aligns **custom-port** setup guidance with the current Cypress config after the `env` → `expose` migration.
> 
> **README** now tells developers to edit `e2e.baseUrl`, `expose.apiUrl`, and `expose.codeCoverage.url` (instead of `env.apiUrl` / `env.url`), and the example snippet uses an `expose` block including `codeCoverage.url`.
> 
> **`portUtils.ts`** updates the backend port-conflict console message to reference `expose.apiUrl` in `cypress.config.ts` instead of `apiUrl` in `cypress.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc471c5d3ef9ce109f42ceb6a30e9c10075173ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->