### PR TITLE
fix: assert one CSS property at a time in have.css

### DIFF
--- a/cypress/tests/ui/transaction-feeds.spec.ts
+++ b/cypress/tests/ui/transaction-feeds.spec.ts
@@ -191,7 +191,7 @@ describe("Transaction Feed", function () {
         cy.getBySelLike(feed.tab)
           .should("have.class", "Mui-selected")
           .contains(feed.tabLabel, { matchCase: false })
-          .should("have.css", { "text-transform": "uppercase" });
+          .should("have.css", "text-transform", "uppercase");
         cy.getBySel("list-skeleton").should("not.exist");
         cy.visualSnapshot(`Paginate ${feedName}`);
 
@@ -302,7 +302,7 @@ describe("Transaction Feed", function () {
         cy.getBySelLike("empty-create-transaction-button")
           .should("have.attr", "href", "/transaction/new")
           .contains("create a transaction", { matchCase: false })
-          .should("have.css", { "text-transform": "uppercase" });
+          .should("have.css", "text-transform", "uppercase");
         cy.visualSnapshot("No Transactions");
       });
     });
@@ -379,7 +379,7 @@ describe("Transaction Feed", function () {
         cy.getBySelLike("empty-create-transaction-button")
           .should("have.attr", "href", "/transaction/new")
           .contains("create a transaction", { matchCase: false })
-          .should("have.css", { "text-transform": "uppercase" });
+          .should("have.css", "text-transform", "uppercase");
         cy.visualSnapshot("No Transactions");
       });
     });


### PR DESCRIPTION
### Problem

The `Transaction Feed` spec fails against Cypress `develop` — 9 tests error with:

```
CypressError: The `css` assertion requires the CSS property name to be a string. You passed: `{ 'text-transform': 'uppercase' }`
```

[Failing CircleCI job](https://app.circleci.com/pipelines/github/cypress-io/cypress/85446/workflows/a1b5ea5e-d2c1-49e6-ad0c-2891e616fe1d/jobs/3903406) (binary `beta-15.20.2-develop-4169413c`).

### Cause

[cypress-io/cypress#34544](https://github.com/cypress-io/cypress/pull/34544) — "don't mutate the DOM when have.attr/css/prop is given an object" — landed on `develop`. jQuery's `.css()` doubles as a setter when handed an object, so `.should("have.css", { "text-transform": "uppercase" })` was *applying* `text-transform: uppercase` to the subject and then trivially passing. Cypress now requires the property name to be a string and errors on the object form instead of silently mutating the DOM.

Three assertion sites used the object form; each sits inside an `_.each(feedViews)` loop over the public/contacts/personal feeds, which is why 3 sites produced 9 failures.

### Change

Switched all three to the two-argument form, matching the `have.css` assertions for `color` already used elsewhere in the same file:

```diff
-  .should("have.css", { "text-transform": "uppercase" });
+  .should("have.css", "text-transform", "uppercase");
```

These were the only object-form assertions in the repo.

### Verification

Ran the spec locally (Node 22.20.0, Cypress 15.17.0, Electron): **20 passing, 0 failing**. This is worth noting because the old assertions never actually verified anything — the passing run confirms MUI really does compute `text-transform: uppercase` on those elements, so the assertions are now genuine rather than merely non-erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; assertions now actually verify computed styles instead of accidentally passing via DOM mutation.
> 
> **Overview**
> Updates **Transaction Feed** Cypress specs so `have.css` uses the **property name + expected value** form instead of passing a CSS object.
> 
> Three assertions (tab label and empty-state CTA, each exercised across the public/contacts/personal feed loops) now call `.should("have.css", "text-transform", "uppercase")`, aligned with existing `color` checks in the same file. This matches Cypress `develop` behavior after object arguments to `have.css` are rejected instead of mutating the DOM.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffffc75bf68902e11bb868727cc8d1cfc24ea427. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->